### PR TITLE
ci(github): added dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    assignees:
+      - rhysmcneill
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+    assignees:
+      - rhysmcneill


### PR DESCRIPTION
The `dependabot.yml` file was added as requested with the addition of `assignee`.