### PR TITLE
ci(e2e): remove redundant build dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-cover:
 	go tool cover -func=coverage.out
 
 # Run CLI smoke tests against the compiled binary (no AWS required).
-e2e: build
+e2e:
 	go test ./e2e/ -v -count=1
 
 # Run full AWS integration tests (requires real AWS credentials).


### PR DESCRIPTION
## Summary

- remove the redundant `build` prerequisite from the `e2e` Make target
- keep `make e2e` focused on running the smoke tests, which already build their own temporary test binary

Closes #18

## Validation

- `make -n e2e` now prints only `go test ./e2e/ -v -count=1`
- `rm -rf bin && make e2e`
- confirmed `bin/ssmctl` is not created by `make e2e`
- `make ci`
- `PATH=/home/ubuntu/go/bin:$PATH make lint`
- `gofmt -l .`
