### PR TITLE
feat(ssm): handle unsupported Windows targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A lightweight CLI for managing AWS SSM connections, remote command execution, an
 - [Global Flags](#global-flags)
 - [Installation](#installation)
 - [Requirements](#requirements)
+- [Target OS support](#target-os-support)
 - [Design Goals](#design-goals)
 - [Project Structure](#project-structure)
 - [Roadmap](#roadmap)
@@ -135,6 +136,23 @@ brew install ssmctl
 - AWS credentials configured (environment variables, `~/.aws/credentials`, or an IAM role)
 - The target EC2 instance must have the [SSM Agent](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html) installed and running
 - For `connect`, the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) must be installed locally
+
+---
+
+## Target OS support
+
+| Command | Linux/macOS targets | Windows targets |
+|---------|---------------------|-----------------|
+| `connect` | Supported | Supported when the Session Manager plugin is installed locally |
+| `run` | Supported via `AWS-RunShellScript` | Not currently supported; Windows targets require `AWS-RunPowerShellScript` |
+| `cp` | Supported | Not currently supported; transfers rely on POSIX utilities such as `cat` and `base64` |
+
+The `run` and `cp` commands currently build shell commands for POSIX-like
+targets. When EC2 metadata identifies a Windows target, these commands return a
+clear unsupported-target error instead of running a shell command that would fail
+remotely. Use `connect` for Windows targets, or run PowerShell commands through
+AWS Systems Manager directly until `ssmctl` gains native Windows command and
+transfer support.
 
 ---
 

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -36,8 +36,10 @@ func TestHelp_RunSubcommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run --help exited with error: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(out, "run") {
-		t.Errorf("run --help output missing 'run':\n%s", out)
+	for _, want := range []string{"run", "Linux/macOS targets", "AWS-RunPowerShellScript"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("run --help output missing %q:\n%s", want, out)
+		}
 	}
 }
 
@@ -46,8 +48,10 @@ func TestHelp_CpSubcommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cp --help exited with error: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(out, "cp") {
-		t.Errorf("cp --help output missing 'cp':\n%s", out)
+	for _, want := range []string{"cp", "Linux/macOS targets only", "POSIX utilities"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("cp --help output missing %q:\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/cmd/connect.go
+++ b/internal/cmd/connect.go
@@ -20,6 +20,8 @@ func connectCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := cmd.Context().Value(app.ContextKey{}).(*app.App)
 
+			// Keep connect available for Windows targets: unlike run/cp, an
+			// interactive SSM session does not build POSIX shell commands locally.
 			instanceID, err := ssmlib.ResolveTarget(cmd.Context(), a.EC2Client, args[0])
 			if err != nil {
 				return fmt.Errorf("resolve target: %w", err)

--- a/internal/cmd/cp.go
+++ b/internal/cmd/cp.go
@@ -21,7 +21,11 @@ is either an instance ID (i-...) or a Name tag.
 Upload:   ssmctl cp ./file.txt my-server:/tmp/file.txt
 Download: ssmctl cp my-server:/var/log/app.log ./app.log
 
-Note: uploads are limited to ~2MB; downloads to ~36KB.`,
+Note: uploads are limited to ~2MB; downloads to ~36KB.
+
+Remote copy support is for Linux/macOS targets only. Uploads and downloads
+construct remote shell commands that depend on POSIX utilities such as cat and
+base64, which are not available by default on Windows targets.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := cmd.Context().Value(app.ContextKey{}).(*app.App)
@@ -31,18 +35,24 @@ Note: uploads are limited to ~2MB; downloads to ~36KB.`,
 
 			switch {
 			case srcRemote && !dstRemote:
-				instanceID, err := ssmlib.ResolveTarget(cmd.Context(), a.EC2Client, srcInstance)
+				target, err := ssmlib.ResolveTargetInfo(cmd.Context(), a.EC2Client, srcInstance)
 				if err != nil {
 					return err
 				}
-				return ssmlib.Download(cmd.Context(), a.SSMClient, instanceID, srcPath, dstPath, a.Config.Timeout)
+				if target.IsWindows() {
+					return fmt.Errorf("cp does not currently support Windows targets; remote copy relies on POSIX utilities such as cat and base64")
+				}
+				return ssmlib.Download(cmd.Context(), a.SSMClient, target.InstanceID, srcPath, dstPath, a.Config.Timeout)
 
 			case !srcRemote && dstRemote:
-				instanceID, err := ssmlib.ResolveTarget(cmd.Context(), a.EC2Client, dstInstance)
+				target, err := ssmlib.ResolveTargetInfo(cmd.Context(), a.EC2Client, dstInstance)
 				if err != nil {
 					return err
 				}
-				return ssmlib.Upload(cmd.Context(), a.SSMClient, instanceID, srcPath, dstPath, a.Config.Timeout)
+				if target.IsWindows() {
+					return fmt.Errorf("cp does not currently support Windows targets; remote copy relies on POSIX utilities such as cat and base64")
+				}
+				return ssmlib.Upload(cmd.Context(), a.SSMClient, target.InstanceID, srcPath, dstPath, a.Config.Timeout)
 
 			default:
 				return fmt.Errorf("exactly one of src or dst must be a remote path (e.g. my-server:/tmp/file.txt)")

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -14,7 +14,12 @@ func runCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "run <target> -- <command>",
 		Short: "Execute a command on a target instance via SSM",
-		Args:  cobra.MinimumNArgs(1),
+		Long: `Execute a command on a target instance via SSM.
+
+The run command uses the AWS-RunShellScript document and is intended for
+Linux/macOS targets. Windows targets require AWS-RunPowerShellScript, which
+ssmctl does not currently select automatically.`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := cmd.Context().Value(app.ContextKey{}).(*app.App)
 
@@ -26,12 +31,15 @@ func runCmd() *cobra.Command {
 			target := args[0]
 			command := args[dashAt:]
 
-			instanceID, err := ssmlib.ResolveTarget(cmd.Context(), a.EC2Client, target)
+			targetInfo, err := ssmlib.ResolveTargetInfo(cmd.Context(), a.EC2Client, target)
 			if err != nil {
 				return err
 			}
+			if targetInfo.IsWindows() {
+				return fmt.Errorf("run does not currently support Windows targets; Windows targets require AWS-RunPowerShellScript, which ssmctl does not currently select automatically")
+			}
 
-			result, err := ssmlib.RunCommand(cmd.Context(), a.SSMClient, instanceID, command, a.Config.Timeout)
+			result, err := ssmlib.RunCommand(cmd.Context(), a.SSMClient, targetInfo.InstanceID, command, a.Config.Timeout)
 			if err != nil {
 				return err
 			}

--- a/internal/ssm/client.go
+++ b/internal/ssm/client.go
@@ -14,32 +14,98 @@ type EC2DescribeInstancesAPI interface {
 	DescribeInstances(ctx context.Context, in *ec2.DescribeInstancesInput, opts ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
 }
 
+type TargetInfo struct {
+	InstanceID string
+	Platform   types.PlatformValues
+}
+
+func (t TargetInfo) IsWindows() bool {
+	return t.Platform == types.PlatformValuesWindows
+}
+
 func ResolveTarget(ctx context.Context, ec2Client EC2DescribeInstancesAPI, target string) (string, error) {
-	switch {
-	case strings.HasPrefix(target, "i-"):
+	if strings.HasPrefix(target, "i-") {
 		return target, nil
-	default:
-		instances, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-			Filters: []types.Filter{
-				{
-					Name:   aws.String("tag:Name"),
-					Values: []string{target},
-				},
-				{
-					Name:   aws.String("instance-state-name"),
-					Values: []string{string(types.InstanceStateNameRunning)},
-				},
-			},
-		})
-
-		if err != nil {
-			return "", err
-		}
-
-		if len(instances.Reservations) == 0 || len(instances.Reservations[0].Instances) == 0 {
-			return "", fmt.Errorf("instance not found: %s", target)
-		}
-
-		return *instances.Reservations[0].Instances[0].InstanceId, nil
 	}
+
+	info, err := lookupTargetByName(ctx, ec2Client, target)
+	if err != nil {
+		return "", err
+	}
+
+	return info.InstanceID, nil
+}
+
+func ResolveTargetInfo(ctx context.Context, ec2Client EC2DescribeInstancesAPI, target string) (TargetInfo, error) {
+	if strings.HasPrefix(target, "i-") {
+		return lookupTargetByInstanceID(ctx, ec2Client, target), nil
+	}
+
+	return lookupTargetByName(ctx, ec2Client, target)
+}
+
+func lookupTargetByInstanceID(ctx context.Context, ec2Client EC2DescribeInstancesAPI, instanceID string) TargetInfo {
+	fallback := TargetInfo{InstanceID: instanceID}
+	if ec2Client == nil {
+		return fallback
+	}
+
+	instances, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	if err != nil {
+		// Instance IDs used to pass through without an EC2 lookup. Keep that behavior
+		// when platform metadata cannot be read, and let the SSM operation fail normally.
+		return fallback
+	}
+
+	instance, ok := firstInstance(instances)
+	if !ok {
+		return fallback
+	}
+
+	return targetInfoFromInstance(instanceID, instance)
+}
+
+func lookupTargetByName(ctx context.Context, ec2Client EC2DescribeInstancesAPI, target string) (TargetInfo, error) {
+	instances, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: []string{target},
+			},
+			{
+				Name:   aws.String("instance-state-name"),
+				Values: []string{string(types.InstanceStateNameRunning)},
+			},
+		},
+	})
+
+	if err != nil {
+		return TargetInfo{}, err
+	}
+
+	instance, ok := firstInstance(instances)
+	if !ok {
+		return TargetInfo{}, fmt.Errorf("instance not found: %s", target)
+	}
+
+	return targetInfoFromInstance(target, instance), nil
+}
+
+func firstInstance(instances *ec2.DescribeInstancesOutput) (types.Instance, bool) {
+	if instances == nil || len(instances.Reservations) == 0 || len(instances.Reservations[0].Instances) == 0 {
+		return types.Instance{}, false
+	}
+
+	return instances.Reservations[0].Instances[0], true
+}
+
+func targetInfoFromInstance(fallbackID string, instance types.Instance) TargetInfo {
+	instanceID := aws.ToString(instance.InstanceId)
+	if instanceID == "" {
+		instanceID = fallbackID
+	}
+
+	return TargetInfo{InstanceID: instanceID, Platform: instance.Platform}
 }

--- a/internal/ssm/client_test.go
+++ b/internal/ssm/client_test.go
@@ -13,9 +13,11 @@ import (
 type mockEC2Client struct {
 	output *ec2.DescribeInstancesOutput
 	err    error
+	input  *ec2.DescribeInstancesInput
 }
 
-func (m *mockEC2Client) DescribeInstances(_ context.Context, _ *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+func (m *mockEC2Client) DescribeInstances(_ context.Context, in *ec2.DescribeInstancesInput, _ ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	m.input = in
 	return m.output, m.err
 }
 
@@ -92,6 +94,66 @@ func TestResolveTarget(t *testing.T) {
 			}
 			if id != tt.wantID {
 				t.Errorf("ResolveTarget() = %q, want %q", id, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestResolveTargetInfo(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      string
+		mockEC2     *mockEC2Client
+		wantID      string
+		wantWindows bool
+		wantErr     bool
+	}{
+		{
+			name:   "name lookup keeps Windows platform metadata",
+			target: "windows-server",
+			mockEC2: &mockEC2Client{output: &ec2.DescribeInstancesOutput{Reservations: []types.Reservation{
+				{Instances: []types.Instance{{InstanceId: aws.String("i-windows"), Platform: types.PlatformValuesWindows}}},
+			}}},
+			wantID:      "i-windows",
+			wantWindows: true,
+		},
+		{
+			name:   "instance ID lookup keeps Windows platform metadata",
+			target: "i-1234567890abcdef0",
+			mockEC2: &mockEC2Client{output: &ec2.DescribeInstancesOutput{Reservations: []types.Reservation{
+				{Instances: []types.Instance{{InstanceId: aws.String("i-1234567890abcdef0"), Platform: types.PlatformValuesWindows}}},
+			}}},
+			wantID:      "i-1234567890abcdef0",
+			wantWindows: true,
+		},
+		{
+			name:    "instance ID metadata lookup failure preserves passthrough",
+			target:  "i-1234567890abcdef0",
+			mockEC2: &mockEC2Client{err: errors.New("access denied")},
+			wantID:  "i-1234567890abcdef0",
+			wantErr: false,
+		},
+		{
+			name:   "name lookup not found still errors",
+			target: "missing-server",
+			mockEC2: &mockEC2Client{output: &ec2.DescribeInstancesOutput{
+				Reservations: []types.Reservation{},
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := ResolveTargetInfo(context.Background(), tt.mockEC2, tt.target)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveTargetInfo() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if info.InstanceID != tt.wantID {
+				t.Errorf("ResolveTargetInfo().InstanceID = %q, want %q", info.InstanceID, tt.wantID)
+			}
+			if info.IsWindows() != tt.wantWindows {
+				t.Errorf("ResolveTargetInfo().IsWindows() = %v, want %v", info.IsWindows(), tt.wantWindows)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- document per-command target OS support in the README
- add run/cp help text that explains the current Windows limitations
- detect Windows targets from EC2 platform metadata for `run` and `cp`, returning clear unsupported-target errors instead of invoking POSIX shell commands that would fail remotely
- preserve the existing instance-ID passthrough behavior when platform metadata cannot be read

Closes #14.

## Validation

- `go test ./internal/ssm -run 'TestResolveTarget|TestResolveTargetInfo' -v -count=1`
- `go test ./e2e/ -run 'TestHelp_(Run|Cp)Subcommand' -v -count=1`
- `PATH=/home/ubuntu/go/bin:$PATH make lint`
- `make ci`
