### PR TITLE
fix(app): refactor sentinel ExitCodeError and implement interface-driven App clients

### DIFF
--- a/cmd/ssmctl/main.go
+++ b/cmd/ssmctl/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/rhysmcneill/ssmctl/internal/cmd"
@@ -9,6 +10,10 @@ import (
 
 func main() {
 	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		if exitErr, ok := err.(*cmd.ExitCodeError); ok {
+			os.Exit(exitErr.ExitCode)
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -19,7 +19,7 @@ import (
 // App struct contains the AWS SSM and EC2 clients, configuration, and output printer for the ssmctl application.
 type App struct {
 	Config    *config.Config
-	SSMClient ssmlib.SSMClientAPI
+	SSMClient ssmlib.ClientAPI
 	EC2Client ssmlib.EC2DescribeInstancesAPI
 	Printer   *output.Printer
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,13 +13,14 @@ import (
 
 	"github.com/rhysmcneill/ssmctl/internal/config"
 	"github.com/rhysmcneill/ssmctl/internal/output"
+	ssmlib "github.com/rhysmcneill/ssmctl/internal/ssm"
 )
 
 // App struct contains the AWS SSM and EC2 clients, configuration, and output printer for the ssmctl application.
 type App struct {
 	Config    *config.Config
-	SSMClient *ssm.Client
-	EC2Client *ec2.Client
+	SSMClient ssmlib.SSMClientAPI
+	EC2Client ssmlib.EC2DescribeInstancesAPI
 	Printer   *output.Printer
 }
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -10,6 +10,14 @@ import (
 	ssmlib "github.com/rhysmcneill/ssmctl/internal/ssm"
 )
 
+type ExitCodeError struct {
+	ExitCode int
+}
+
+func (e *ExitCodeError) Error() string {
+	return fmt.Sprintf("command exited with code %d", e.ExitCode)
+}
+
 func runCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "run <target> -- <command>",
@@ -43,7 +51,7 @@ func runCmd() *cobra.Command {
 				fmt.Fprint(os.Stderr, result.Stderr)
 			}
 			if result.ExitCode != 0 {
-				os.Exit(result.ExitCode)
+				return &ExitCodeError{ExitCode: result.ExitCode}
 			}
 
 			return nil

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -10,6 +10,8 @@ import (
 	ssmlib "github.com/rhysmcneill/ssmctl/internal/ssm"
 )
 
+// ExitCodeError is returned by RunE when a remote command exits with a
+// non-zero status. main inspects this type to forward the exact exit code.
 type ExitCodeError struct {
 	ExitCode int
 }

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/spf13/cobra"
+
+	"github.com/rhysmcneill/ssmctl/internal/app"
+	"github.com/rhysmcneill/ssmctl/internal/config"
+)
+
+// mockSSMCmdClient implements ssmlib.SSMClientAPI for cmd-layer tests.
+type mockSSMCmdClient struct {
+	sendCommandFn          func(context.Context, *awsssm.SendCommandInput, ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error)
+	getCommandInvocationFn func(context.Context, *awsssm.GetCommandInvocationInput, ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error)
+}
+
+func (m *mockSSMCmdClient) SendCommand(ctx context.Context, in *awsssm.SendCommandInput, opts ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+	return m.sendCommandFn(ctx, in, opts...)
+}
+
+func (m *mockSSMCmdClient) GetCommandInvocation(ctx context.Context, in *awsssm.GetCommandInvocationInput, opts ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+	return m.getCommandInvocationFn(ctx, in, opts...)
+}
+
+func (m *mockSSMCmdClient) StartSession(_ context.Context, _ *awsssm.StartSessionInput, _ ...func(*awsssm.Options)) (*awsssm.StartSessionOutput, error) {
+	panic("unexpected call to StartSession in run command test")
+}
+
+// executeRunCmd builds a root cobra command, attaches runCmd, and executes it
+// with the given args and app injected into the context. Errors from RunE are
+// returned directly (SilenceErrors suppresses cobra's own printing).
+func executeRunCmd(ctx context.Context, a *app.App, args []string) error {
+	root := &cobra.Command{Use: "ssmctl", SilenceErrors: true, SilenceUsage: true}
+	root.AddCommand(runCmd())
+	root.SetArgs(args)
+	return root.ExecuteContext(context.WithValue(ctx, app.ContextKey{}, a))
+}
+
+func TestRunCmd_NonZeroExitCodeReturnsExitCodeError(t *testing.T) {
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, _ *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			return &awsssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-test")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			return &awsssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusFailed,
+				ResponseCode: 127,
+			}, nil
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Timeout: 30 * time.Second},
+		SSMClient: client,
+	}
+
+	err := executeRunCmd(context.Background(), a, []string{"run", "i-123", "--", "echo", "hi"})
+
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *ExitCodeError, got %v (%T)", err, err)
+	}
+	if exitErr.ExitCode != 127 {
+		t.Errorf("ExitCode = %d, want 127", exitErr.ExitCode)
+	}
+}
+
+func TestRunCmd_MissingDashDashReturnsError(t *testing.T) {
+	a := &app.App{
+		Config: &config.Config{Timeout: 30 * time.Second},
+	}
+
+	err := executeRunCmd(context.Background(), a, []string{"run", "i-123"})
+	if err == nil {
+		t.Fatal("expected error for missing --, got nil")
+	}
+}
+
+func TestExitCodeError_Error(t *testing.T) {
+	err := &ExitCodeError{ExitCode: 42}
+	want := "command exited with code 42"
+	if err.Error() != want {
+		t.Errorf("Error() = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestExitCodeError_TypeAssertion(t *testing.T) {
+	var err error = &ExitCodeError{ExitCode: 127}
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatal("expected errors.As to match *ExitCodeError")
+	}
+	if exitErr.ExitCode != 127 {
+		t.Errorf("ExitCode = %d, want 127", exitErr.ExitCode)
+	}
+}

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -40,7 +40,10 @@ func executeRunCmd(ctx context.Context, a *app.App, args []string) error {
 	root := &cobra.Command{Use: "ssmctl", SilenceErrors: true, SilenceUsage: true}
 	root.AddCommand(runCmd())
 	root.SetArgs(args)
-	return root.ExecuteContext(context.WithValue(ctx, app.ContextKey{}, a))
+	if err := root.ExecuteContext(context.WithValue(ctx, app.ContextKey{}, a)); err != nil {
+		return err //nolint:wrapcheck // cobra unwraps RunE errors; wrapping here would hide *ExitCodeError
+	}
+	return nil
 }
 
 func TestRunCmd_NonZeroExitCodeReturnsExitCodeError(t *testing.T) {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -19,7 +19,6 @@ func (p *Printer) Print(v any) error {
 	return p.Fprint(os.Stdout, v)
 }
 
-
 // Fprint writes the value to the given writer using the configured format.
 // It supports "json" format with indentation and "text" format.
 func (p *Printer) Fprint(w io.Writer, v any) error {

--- a/internal/ssm/connect.go
+++ b/internal/ssm/connect.go
@@ -10,8 +10,17 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
+// SSMClientAPI is the superset of SSM client methods used by this package.
+// It combines RunAPI (used by RunCommand, Upload, Download) with StartSession
+// so that a single interface can be stored in app.App and mocked in tests.
+// *ssm.Client satisfies this interface automatically.
+type SSMClientAPI interface {
+	RunAPI
+	StartSession(ctx context.Context, params *ssm.StartSessionInput, optFns ...func(*ssm.Options)) (*ssm.StartSessionOutput, error)
+}
+
 // StartSession starts an interactive SSM session with a target instance
-func StartSession(ctx context.Context, client *ssm.Client, instanceID, region, profile string) error {
+func StartSession(ctx context.Context, client SSMClientAPI, instanceID, region, profile string) error {
 	if region == "" {
 		return fmt.Errorf("could not determine AWS region: set --region, AWS_REGION, AWS_DEFAULT_REGION, or configure a default region in ~/.aws/config")
 	}

--- a/internal/ssm/connect.go
+++ b/internal/ssm/connect.go
@@ -10,17 +10,17 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
-// SSMClientAPI is the superset of SSM client methods used by this package.
+// ClientAPI is the superset of SSM client methods used by this package.
 // It combines RunAPI (used by RunCommand, Upload, Download) with StartSession
 // so that a single interface can be stored in app.App and mocked in tests.
 // *ssm.Client satisfies this interface automatically.
-type SSMClientAPI interface {
+type ClientAPI interface {
 	RunAPI
 	StartSession(ctx context.Context, params *ssm.StartSessionInput, optFns ...func(*ssm.Options)) (*ssm.StartSessionOutput, error)
 }
 
 // StartSession starts an interactive SSM session with a target instance
-func StartSession(ctx context.Context, client SSMClientAPI, instanceID, region, profile string) error {
+func StartSession(ctx context.Context, client ClientAPI, instanceID, region, profile string) error {
 	if region == "" {
 		return fmt.Errorf("could not determine AWS region: set --region, AWS_REGION, AWS_DEFAULT_REGION, or configure a default region in ~/.aws/config")
 	}


### PR DESCRIPTION
## Summary
Replace os.Exit in RunE with ExitCodeError returned to main, program App
clients to interfaces, and add cmd-layer tests without real AWS connections.

## Related issue
closes #9 

## What changed

- exitcode in RunE and returned to main
- integrate better interface for app clients for testing purposes

## Testing performed
make test
make lint

## Checklist
- [x] I linked the related issue when applicable
- [x] I reviewed testing standards in CONTRIBUTING.md
- [x] I ran lint and formatting checks or explained why skipped
- [x] I updated docs/comments if needed
- [x] I followed commit conventions
- [x] This PR is focused on one logical change