### PR TITLE
fix(client): resolve an issue where by targets share the same name tag in AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ bin/
 .agents/
 *.local.*
 plan.md
+# AI Agent Configuration (managed by @rhysmcneill/agentic-ai-library github.com)
+AGENTS.local.md
+.cursor/skills/
+AGENTS.md

--- a/internal/ssm/client.go
+++ b/internal/ssm/client.go
@@ -96,6 +96,14 @@ func lookupTargetByName(ctx context.Context, ec2Client EC2DescribeInstancesAPI, 
 		return TargetInfo{}, fmt.Errorf("describe instance: %w", err)
 	}
 
+	if noInstancesFound(instances) {
+		return TargetInfo{}, fmt.Errorf("no instances found for name: %s", target)
+	}
+
+	if ids := allInstanceIDs(instances); len(ids) > 1 {
+		return TargetInfo{}, fmt.Errorf("multiple running instances match Name %q (%s) — use an instance ID instead", target, strings.Join(ids, ", "))
+	}
+
 	instance, ok := firstInstance(instances)
 	if !ok {
 		return TargetInfo{}, fmt.Errorf("instance not found: %s", target)
@@ -110,6 +118,27 @@ func firstInstance(instances *ec2.DescribeInstancesOutput) (types.Instance, bool
 	}
 
 	return instances.Reservations[0].Instances[0], true
+}
+
+func allInstanceIDs(instances *ec2.DescribeInstancesOutput) []string {
+	var ids []string
+	if instances == nil {
+		return ids
+	}
+	for _, r := range instances.Reservations {
+		for _, inst := range r.Instances {
+			ids = append(ids, aws.ToString(inst.InstanceId))
+		}
+	}
+	return ids
+}
+
+func noInstancesFound(instances *ec2.DescribeInstancesOutput) bool {
+	if instances == nil || len(instances.Reservations) == 0 {
+		return true
+	}
+
+	return false
 }
 
 func targetInfoFromInstance(fallbackID string, instance types.Instance) TargetInfo {

--- a/internal/ssm/client_test.go
+++ b/internal/ssm/client_test.go
@@ -3,6 +3,7 @@ package ssm
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -84,6 +85,37 @@ func TestResolveTarget(t *testing.T) {
 			wantID:  "",
 			wantErr: true,
 		},
+		{
+			name:   "multiple instances across reservations returns error",
+			target: "my-server",
+			mockEC2: &mockEC2Client{
+				output: &ec2.DescribeInstancesOutput{
+					Reservations: []types.Reservation{
+						{Instances: []types.Instance{{InstanceId: aws.String("i-aaa")}}},
+						{Instances: []types.Instance{{InstanceId: aws.String("i-bbb")}}},
+					},
+				},
+			},
+			wantID:  "",
+			wantErr: true,
+		},
+		{
+			name:   "multiple instances in single reservation returns error",
+			target: "my-server",
+			mockEC2: &mockEC2Client{
+				output: &ec2.DescribeInstancesOutput{
+					Reservations: []types.Reservation{
+						{Instances: []types.Instance{
+							{InstanceId: aws.String("i-aaa")},
+							{InstanceId: aws.String("i-bbb")},
+							{InstanceId: aws.String("i-ccc")},
+						}},
+					},
+				},
+			},
+			wantID:  "",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -141,6 +173,17 @@ func TestResolveTargetInfo(t *testing.T) {
 			}},
 			wantErr: true,
 		},
+		{
+			name:   "multiple instances match name still errors",
+			target: "my-server",
+			mockEC2: &mockEC2Client{output: &ec2.DescribeInstancesOutput{
+				Reservations: []types.Reservation{
+					{Instances: []types.Instance{{InstanceId: aws.String("i-aaa"), Platform: types.PlatformValuesWindows}}},
+					{Instances: []types.Instance{{InstanceId: aws.String("i-bbb")}}},
+				},
+			}},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -156,5 +199,32 @@ func TestResolveTargetInfo(t *testing.T) {
 				t.Errorf("ResolveTargetInfo().IsWindows() = %v, want %v", info.IsWindows(), tt.wantWindows)
 			}
 		})
+	}
+}
+
+func TestResolveTargetAmbiguousErrorMessage(t *testing.T) {
+	mock := &mockEC2Client{
+		output: &ec2.DescribeInstancesOutput{
+			Reservations: []types.Reservation{
+				{Instances: []types.Instance{{InstanceId: aws.String("i-aaa")}}},
+				{Instances: []types.Instance{{InstanceId: aws.String("i-bbb")}}},
+				{Instances: []types.Instance{{InstanceId: aws.String("i-ccc")}}},
+			},
+		},
+	}
+
+	_, err := ResolveTarget(context.Background(), mock, "my-server")
+	if err == nil {
+		t.Fatal("expected error for ambiguous name, got nil")
+	}
+
+	msg := err.Error()
+	for _, id := range []string{"i-aaa", "i-bbb", "i-ccc"} {
+		if !strings.Contains(msg, id) {
+			t.Errorf("error message %q does not contain instance ID %s", msg, id)
+		}
+	}
+	if !strings.Contains(msg, "my-server") {
+		t.Errorf("error message %q does not contain the target name", msg)
 	}
 }


### PR DESCRIPTION
## Summary
`ResolveTarget` could resolve to multiple AWS name tags and it would not produce an error, instead would connect to the first instance it discovered. 

## Related issue
closes #8 

## What changed

1. `lookupTargetByName` now checks if the returned instances have multiple IDs - Porduced an err to the user and tells them which instance IDs they can connect to with this name.
2. Updated `client_test.go` to include tests for the scenario

## Testing performed
make test
make lint
make fmt

## Checklist
N/A