### PR TITLE
fix(internal): wired debug flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,14 @@ Aim to keep unit test coverage above 80 % for packages in `internal/`. Check cov
 make test-cover
 ```
 
+### Debug Mode Testing
+
+When making changes to AWS SDK interactions, test with the `--debug` flag: 
+
+```bash
+ssmctl --debug run i-xxx -- whoami
+```
+
 ---
 
 ## Commit Messages

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -52,11 +52,11 @@ func New(cfg *config.Config) (*App, error) {
 		return nil, fmt.Errorf("load AWS config: %w", err)
 	}
 
-	// if debug flag was passed, additional information is logged.
+	// If the debug flag is set, log AWS SDK initialisation details.
 	if cfg.Debug {
 		debugLog := log.New(os.Stderr, "[DEBUG] ", log.LstdFlags)
 		debugLog.Println("AWS SDK initialized")
-		debugLog.Printf("Profile %s\n", cfg.Profile)
+		debugLog.Printf("Profile: %s\n", cfg.Profile)
 		debugLog.Printf("Region: %s\n", awsCfg.Region)
 		debugLog.Printf("Output: %s\n", cfg.Output)
 		debugLog.Printf("Timeout: %v\n", cfg.Timeout)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -55,10 +54,12 @@ func New(cfg *config.Config) (*App, error) {
 
 	// if debug flag was passed, additional information is logged.
 	if cfg.Debug {
-		awsCfg.ClientLogMode = aws.LogSigning | aws.LogRequest | aws.LogResponseWithBody
 		debugLog := log.New(os.Stderr, "[DEBUG] ", log.LstdFlags)
 		debugLog.Println("AWS SDK initialized")
-		debugLog.Printf("Resolved Region: %s\n", awsCfg.Region)
+		debugLog.Printf("Profile %s\n", cfg.Profile)
+		debugLog.Printf("Region: %s\n", awsCfg.Region)
+		debugLog.Printf("Output: %s\n", cfg.Output)
+		debugLog.Printf("Timeout: %v\n", cfg.Timeout)
 	}
 	// Sync the resolved region back onto cfg so commands that need to pass the
 	// region explicitly (e.g. the session-manager-plugin invocation) get the

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,7 +6,10 @@ package app
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -50,6 +53,13 @@ func New(cfg *config.Config) (*App, error) {
 		return nil, fmt.Errorf("load AWS config: %w", err)
 	}
 
+	// if debug flag was passed, additional information is logged.
+	if cfg.Debug {
+		awsCfg.ClientLogMode = aws.LogSigning | aws.LogRequest | aws.LogResponseWithBody
+		debugLog := log.New(os.Stderr, "[DEBUG] ", log.LstdFlags)
+		debugLog.Println("AWS SDK initialized")
+		debugLog.Printf("Resolved Region: %s\n", awsCfg.Region)
+	}
 	// Sync the resolved region back onto cfg so commands that need to pass the
 	// region explicitly (e.g. the session-manager-plugin invocation) get the
 	// value from AWS_REGION / AWS_DEFAULT_REGION / ~/.aws/config, not just

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -211,3 +211,57 @@ func TestRunCmd_JSONOutput_NonZeroExitCode(t *testing.T) {
 		t.Errorf("exitCode = %d, want 127", got.ExitCode)
 	}
 }
+
+func TestRunCmd_DebugFlagDoesNotBreakExecution(t *testing.T) {
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, _ *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			return &awsssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-test")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			return &awsssm.GetCommandInvocationOutput{
+				Status:                types.CommandInvocationStatusSuccess,
+				ResponseCode:          0,
+				StandardOutputContent: aws.String("hello"),
+			}, nil
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Timeout: 30 * time.Second, Debug: true},
+		SSMClient: client,
+	}
+
+	err := executeRunCmd(context.Background(), a, []string{"run", "i-123", "--", "echo", "hi"})
+	if err != nil {
+		t.Fatalf("expected no error with debug flag, got %v", err)
+	}
+}
+
+func TestRunCmd_DebugFlagWithFailingCommand(t *testing.T) {
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, _ *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			return &awsssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-test")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			return &awsssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusFailed,
+				ResponseCode: 1,
+			}, nil
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Timeout: 30 * time.Second, Debug: true},
+		SSMClient: client,
+	}
+
+	err := executeRunCmd(context.Background(), a, []string{"run", "i-123", "--", "false"})
+	var exitErr *ExitCodeError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode != 1 {
+		t.Fatalf("expected exit code 1 with debug flag, got %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,8 @@ package config
 import (
 	"fmt"
 	"time"
+	"os"
+	"log"
 )
 
 // Config holds all configuration options for ssmctl including AWS credentials,
@@ -31,5 +33,12 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("timeout must be greater than 0")
 	}
 
+	if c.Debug {
+		debugLog := log.New(os.Stderr, "[DEBUG] ", log.LstdFlags)
+		debugLog.Printf("Profile: %s\n", c.Profile)
+		debugLog.Printf("Region: %s\n", c.Region)
+		debugLog.Printf("Output: %s\n", c.Output)
+		debugLog.Printf("Timeout: %v\n", c.Timeout)
+	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,8 +6,6 @@ package config
 import (
 	"fmt"
 	"time"
-	"os"
-	"log"
 )
 
 // Config holds all configuration options for ssmctl including AWS credentials,
@@ -33,12 +31,5 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("timeout must be greater than 0")
 	}
 
-	if c.Debug {
-		debugLog := log.New(os.Stderr, "[DEBUG] ", log.LstdFlags)
-		debugLog.Printf("Profile: %s\n", c.Profile)
-		debugLog.Printf("Region: %s\n", c.Region)
-		debugLog.Printf("Output: %s\n", c.Output)
-		debugLog.Printf("Timeout: %v\n", c.Timeout)
-	}
 	return nil
 }


### PR DESCRIPTION
## Summary
Debug flag was wired through `config/config.go`. 

## Related issue

Closes #7 

## What changed
Added debug section in `CONTRIBUTING.MD`
Added config info (i.e., Profile, Region, Output, Timeout) logging in `config/config.go`
`app/app.go` now checks for the debug flag and if true, changes AWS logging to include `aws.LogSigning`, `aws.LogRequest` and `aws.LogResponseWithBody` as well as logging out the region. 

## Testing performed
make test
make lint

## Checklist
- ✅  I linked the related issue when applicable
- ✅  I reviewed testing standards in CONTRIBUTING.md
- ✅  I ran lint and formatting checks or explained why skipped
- ✅  I updated docs/comments if needed
- ✅  I followed commit conventions
- ✅  This PR is focused on one logical change
