### PR TITLE
ci: expand platform coverage and security checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           retention-days: 7
 
       - name: Build
-        run: go build -o bin/ssmctl ./cmd/ssmctl
+        run: make build
 
       - name: Smoke tests (e2e, no AWS)
         run: go test ./e2e/ -v -count=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,13 @@ permissions:
 
 jobs:
   ci:
-    name: Test, Build & Smoke
-    runs-on: ubuntu-latest
+    name: Test, Build & Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     if: github.repository == 'rhysmcneill/ssmctl'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,12 +34,12 @@ jobs:
       - name: Upload coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage
+          name: coverage-${{ matrix.os }}
           path: coverage.out
           retention-days: 7
 
       - name: Build
-        run: make build
+        run: go build -o bin/ssmctl ./cmd/ssmctl
 
       - name: Smoke tests (e2e, no AWS)
         run: go test ./e2e/ -v -count=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,19 @@ jobs:
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: latest
+
+  vulncheck:
+    name: Vulnerability Check
+    runs-on: ubuntu-latest
+    if: github.repository == 'rhysmcneill/ssmctl'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: golang/govulncheck-action@v1
         with:
           go-version-file: go.mod
-          cache: true
-
-      - name: Run govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+          package: ./...

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    if: github.repository == 'rhysmcneill/ssmctl'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: github/codeql-action/init@5e316336eb4f107009e477d4bfbfff13d7250fae # v4
+        with:
+          languages: go
+
+      - name: Build
+        run: go build ./cmd/ssmctl
+
+      - uses: github/codeql-action/analyze@5e316336eb4f107009e477d4bfbfff13d7250fae # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,8 @@ name: CodeQL
 on:
   push:
     branches: [main]
-
+  pull_request:
+    branches: [main]
 permissions:
   contents: read
   security-events: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,6 +43,10 @@ jobs:
           TAG="${{ needs.release-please.outputs.tag_name }}"
           test -n "$TAG"
           echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Cross-compile all platforms
+        run: make build-all VERSION="${{ steps.version.outputs.VERSION }}"
+
       - name: Generate checksums
         run: |
           cd bin

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,17 @@ BINARY   = bin/ssmctl
 # ── Build ──────────────────────────────────────────────────────────────────────
 
 build:
+	mkdir -p bin
 	go build $(LDFLAGS) -o $(BINARY) ./cmd/ssmctl
 
 build-all:
-	GOOS=linux   GOARCH=amd64 go build $(LDFLAGS) -o bin/ssmctl-linux-amd64       ./cmd/ssmctl
-	GOOS=linux   GOARCH=arm64 go build $(LDFLAGS) -o bin/ssmctl-linux-arm64       ./cmd/ssmctl
-	GOOS=darwin  GOARCH=amd64 go build $(LDFLAGS) -o bin/ssmctl-darwin-amd64      ./cmd/ssmctl
-	GOOS=darwin  GOARCH=arm64 go build $(LDFLAGS) -o bin/ssmctl-darwin-arm64      ./cmd/ssmctl
-	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o bin/ssmctl-windows-amd64.exe ./cmd/ssmctl
-	GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o bin/ssmctl-windows-arm64.exe ./cmd/ssmctl
+	mkdir -p bin
+	CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build $(LDFLAGS) -o bin/ssmctl-linux-amd64       ./cmd/ssmctl
+	CGO_ENABLED=0 GOOS=linux   GOARCH=arm64 go build $(LDFLAGS) -o bin/ssmctl-linux-arm64       ./cmd/ssmctl
+	CGO_ENABLED=0 GOOS=darwin  GOARCH=amd64 go build $(LDFLAGS) -o bin/ssmctl-darwin-amd64      ./cmd/ssmctl
+	CGO_ENABLED=0 GOOS=darwin  GOARCH=arm64 go build $(LDFLAGS) -o bin/ssmctl-darwin-arm64      ./cmd/ssmctl
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o bin/ssmctl-windows-amd64.exe ./cmd/ssmctl
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o bin/ssmctl-windows-arm64.exe ./cmd/ssmctl
 
 install:
 	go install $(LDFLAGS) ./cmd/ssmctl


### PR DESCRIPTION
## Summary
Expand CI coverage across supported OS runners, add security scanning, and ensure release artifacts are built before checksums are generated.
## Related issue
closes #64 
## What changed
- Run the CI test/vet/build/smoke job on `ubuntu-latest`, `macos-latest`, and `windows-latest`.
- Add a CodeQL workflow for Go security analysis on pushes to `main` and PRs targeting `main`.
- Add `govulncheck` to CI as a dedicated vulnerability check job.
- Run `make build-all` in `release-please.yml` before generating release checksums.
- Rework `make build-all` to cross-compile release artifacts for Linux, macOS, and Windows with `CGO_ENABLED=0`.
## Testing performed
`make ci`
`make build-all VERSION=test`

## Checklist
- [x] I linked the related issue when applicable
- [x] I reviewed testing standards in CONTRIBUTING.md
- [x] I ran lint and formatting checks or explained why skipped
- [x] I updated docs/comments if needed
- [x] I followed commit conventions
- [x] This PR is focused on one logical change