### PR TITLE
fix(session): ignore terminal control signals during session-manager-…

### DIFF
--- a/internal/ssm/forward.go
+++ b/internal/ssm/forward.go
@@ -77,9 +77,11 @@ func parsePort(s string) (int, error) {
 // the SSM API to start a session then hands control to the local
 // session-manager-plugin process, which manages the actual WebSocket tunnel.
 //
-// The function blocks until the plugin exits (i.e. until the user presses
-// Ctrl-C or the session is otherwise terminated). Signal propagation to the
-// plugin subprocess is handled automatically through the shared process group.
+// The function blocks until the plugin exits. Terminal control signals
+// (Ctrl-C, Ctrl-\, Ctrl-Z on POSIX) are intentionally NOT propagated to
+// ssmctl while the plugin is running — see runSessionManagerPlugin for the
+// rationale and issue #85 for the original bug. The plugin itself catches
+// SIGINT to terminate the tunnel cleanly.
 func StartPortForwardingSession(ctx context.Context, client ClientAPI, instanceID, region, profile string, fwd PortForwardingTarget) error {
 	if region == "" {
 		return fmt.Errorf("could not determine AWS region: set --region, AWS_REGION, AWS_DEFAULT_REGION, or configure a default region in %s", awsConfigPath())
@@ -124,6 +126,15 @@ func StartPortForwardingSession(ctx context.Context, client ClientAPI, instanceI
 // it with the standard argument signature used by both connect and forward.
 // It is kept as a named function (rather than an anonymous closure) so it can
 // be assigned to the pluginRunner var without a cyclic reference.
+//
+// While the plugin is running we ignore terminal control signals (SIGINT,
+// SIGQUIT, SIGTSTP on POSIX; SIGINT, SIGBREAK on Windows) so they are
+// delivered only to the plugin subprocess. The plugin puts the local TTY
+// into raw mode for interactive shells, which causes Ctrl-C to travel to
+// the remote PTY as byte 0x03 and generate SIGINT for the remote process.
+// If ssmctl ALSO received the signal, it would exit, the TTY would be
+// reclaimed by the shell, and the plugin's stdin read would fail with EIO
+// — see issue #85.
 func runSessionManagerPlugin(ctx context.Context, respJSON, region, profile, inputJSON string) error {
 	endpoint := "https://ssm." + region + ".amazonaws.com"
 
@@ -143,6 +154,9 @@ func runSessionManagerPlugin(ctx context.Context, respJSON, region, profile, inp
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	restore := ignoreSessionSignalsFn()
+	defer restore()
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("session-manager-plugin exited with error: %w", err)

--- a/internal/ssm/plugin_runner_test.go
+++ b/internal/ssm/plugin_runner_test.go
@@ -1,0 +1,182 @@
+//go:build !windows
+
+package ssm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// installFakePlugin writes a POSIX shell script masquerading as
+// session-manager-plugin into a temp directory, prepends that directory to
+// PATH for the duration of the test, and returns the directory path.
+//
+// `body` is the shell body the fake plugin executes. Use "exit 0" for a
+// successful no-op, "exit N" to simulate failure, or "sleep 0.2; exit 0" to
+// keep the subprocess running long enough to send signals from the test.
+func installFakePlugin(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session-manager-plugin")
+	script := "#!/bin/sh\n" + body + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil { // #nosec G306 -- fake plugin must be executable for the test
+		t.Fatalf("write fake plugin: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return dir
+}
+
+// ---------------------------------------------------------------------------
+// runSessionManagerPlugin — happy path
+// ---------------------------------------------------------------------------
+
+func TestRunSessionManagerPlugin_SuccessfulExitReturnsNil(t *testing.T) {
+	installFakePlugin(t, "exit 0")
+
+	err := runSessionManagerPlugin(context.Background(), "{}", "us-east-1", "", "{}")
+	if err != nil {
+		t.Fatalf("expected nil from clean plugin exit, got %v", err)
+	}
+}
+
+func TestRunSessionManagerPlugin_NonZeroExitIsWrapped(t *testing.T) {
+	installFakePlugin(t, "exit 7")
+
+	err := runSessionManagerPlugin(context.Background(), "{}", "us-east-1", "", "{}")
+	if err == nil {
+		t.Fatal("expected error from non-zero plugin exit, got nil")
+	}
+	if !strings.Contains(err.Error(), "session-manager-plugin exited with error") {
+		t.Errorf("error message lost wrap context: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runSessionManagerPlugin — error paths must not touch signal handlers
+// ---------------------------------------------------------------------------
+
+// TestRunSessionManagerPlugin_LookPathFailureSkipsSignalBlock verifies that
+// when session-manager-plugin is missing from PATH, we return early WITHOUT
+// installing the signal-ignore handlers. Installing them and then returning
+// could leave the parent process unable to receive Ctrl-C if the restore
+// defer is somehow skipped.
+func TestRunSessionManagerPlugin_LookPathFailureSkipsSignalBlock(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent-directory-for-test")
+
+	var ignoreCalled bool
+	prev := ignoreSessionSignalsFn
+	ignoreSessionSignalsFn = func() func() {
+		ignoreCalled = true
+		return func() {}
+	}
+	t.Cleanup(func() { ignoreSessionSignalsFn = prev })
+
+	err := runSessionManagerPlugin(context.Background(), "{}", "us-east-1", "", "{}")
+	if err == nil {
+		t.Fatal("expected error when plugin is not on PATH")
+	}
+	if !strings.Contains(err.Error(), "session-manager-plugin not found") {
+		t.Errorf("error did not describe the missing plugin: %v", err)
+	}
+	if ignoreCalled {
+		t.Error("signal handlers should not be touched when plugin lookup fails")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runSessionManagerPlugin — signal-handling integration
+// ---------------------------------------------------------------------------
+
+// TestRunSessionManagerPlugin_InstallsAndRestoresSignalHook proves the
+// invariant that every call to runSessionManagerPlugin installs the signal
+// hook exactly once and restores it exactly once, regardless of plugin
+// outcome.
+func TestRunSessionManagerPlugin_InstallsAndRestoresSignalHook(t *testing.T) {
+	installFakePlugin(t, "exit 0")
+
+	var ignoreCalls, restoreCalls int
+	prev := ignoreSessionSignalsFn
+	ignoreSessionSignalsFn = func() func() {
+		ignoreCalls++
+		return func() { restoreCalls++ }
+	}
+	t.Cleanup(func() { ignoreSessionSignalsFn = prev })
+
+	if err := runSessionManagerPlugin(context.Background(), "{}", "us-east-1", "", "{}"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ignoreCalls != 1 {
+		t.Errorf("ignoreSessionSignalsFn called %d times, want 1", ignoreCalls)
+	}
+	if restoreCalls != 1 {
+		t.Errorf("restore func called %d times, want 1", restoreCalls)
+	}
+}
+
+// TestRunSessionManagerPlugin_RestoresOnPluginFailure ensures the restore
+// defer fires even when the plugin exits non-zero. Without this guarantee a
+// failed connect attempt would leave the rest of the ssmctl process unable
+// to react to Ctrl-C.
+func TestRunSessionManagerPlugin_RestoresOnPluginFailure(t *testing.T) {
+	installFakePlugin(t, "exit 9")
+
+	var restoreCalls int
+	prev := ignoreSessionSignalsFn
+	ignoreSessionSignalsFn = func() func() {
+		return func() { restoreCalls++ }
+	}
+	t.Cleanup(func() { ignoreSessionSignalsFn = prev })
+
+	if err := runSessionManagerPlugin(context.Background(), "{}", "us-east-1", "", "{}"); err == nil {
+		t.Fatal("expected error from failing fake plugin")
+	}
+	if restoreCalls != 1 {
+		t.Errorf("restore func called %d times, want 1 even on plugin failure", restoreCalls)
+	}
+}
+
+// TestRunSessionManagerPlugin_SIGINTDuringRunDoesNotKillProcess is the
+// end-to-end regression test for issue #85. We start the real
+// runSessionManagerPlugin against a fake plugin that sleeps long enough for
+// us to send SIGINT to ourselves. If the fix is broken, the Go runtime's
+// default SIGINT handler will terminate this test binary and CI will report
+// the test as having failed catastrophically (no PASS line).
+//
+// Notes for future maintainers:
+//   - We use the REAL ignoreSessionSignalsFn here (no mock) because the
+//     point is to verify that SIG_IGN is genuinely installed at the OS
+//     level.
+//   - We send SIGINT via syscall.Kill(getpid, …) rather than via a process
+//     group because the test runner is not the process-group leader of a
+//     controlling terminal.
+//   - 50ms is a comfortable margin for the goroutine to reach the signal
+//     block before we send the signal; the fake plugin sleeps for 200ms
+//     so cmd.Run is still in flight when we deliver SIGINT.
+func TestRunSessionManagerPlugin_SIGINTDuringRunDoesNotKillProcess(t *testing.T) {
+	installFakePlugin(t, "sleep 0.2; exit 0")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runSessionManagerPlugin(context.Background(), "{}", "us-east-1", "", "{}")
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("kill self with SIGINT: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runSessionManagerPlugin returned error after SIGINT: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("runSessionManagerPlugin did not return after fake plugin should have exited")
+	}
+}

--- a/internal/ssm/signals.go
+++ b/internal/ssm/signals.go
@@ -1,0 +1,35 @@
+// TODO(refactor): this file and its platform siblings (signals_unix.go,
+// signals_windows.go) are OS/process concerns that do not belong in the ssm
+// package, whose stated purpose is AWS SSM API interaction. If
+// runSessionManagerPlugin ever grows — reconnect logic, output multiplexing,
+// plugin version detection — consider extracting it and these helpers into an
+// internal/plugin package.
+
+package ssm
+
+import "os/signal"
+
+// ignoreSessionSignalsFn is a package-level variable so tests can substitute
+// the real signal-handling block with a recording fake. Production code must
+// not reassign this outside of test files.
+var ignoreSessionSignalsFn = ignoreSessionSignals
+
+// ignoreSessionSignals installs SIG_IGN for the platform-specific
+// sessionSignals so that terminal control signals (Ctrl-C, Ctrl-\, Ctrl-Z on
+// POSIX; Ctrl-C and Ctrl-Break on Windows) are delivered only to the
+// session-manager-plugin subprocess and not to ssmctl itself.
+//
+// It returns a restore function that resets the default handlers for those
+// signals. Callers must invoke the returned function (typically via defer)
+// before returning, otherwise the signals will remain ignored for the rest
+// of the process lifetime.
+//
+// Without this guard ssmctl exits on Ctrl-C alongside the plugin, the TTY
+// state is left inconsistent, and the plugin's stdin read fails with EIO —
+// see GitHub issue #85.
+func ignoreSessionSignals() (restore func()) {
+	signal.Ignore(sessionSignals...)
+	return func() {
+		signal.Reset(sessionSignals...)
+	}
+}

--- a/internal/ssm/signals_test.go
+++ b/internal/ssm/signals_test.go
@@ -1,0 +1,59 @@
+package ssm
+
+import (
+	"os"
+	"slices"
+	"syscall"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// sessionSignals list — cross-platform
+// ---------------------------------------------------------------------------
+
+// TestSessionSignals_AlwaysIncludesSIGINT guards against regressions where a
+// future refactor accidentally drops SIGINT from the list. SIGINT is the
+// signal that the original bug (#85) was filed against; the others are
+// defense in depth.
+func TestSessionSignals_AlwaysIncludesSIGINT(t *testing.T) {
+	if !slices.Contains(sessionSignals, os.Signal(syscall.SIGINT)) {
+		t.Fatalf("sessionSignals must include SIGINT, got %v", sessionSignals)
+	}
+}
+
+func TestSessionSignals_NonEmpty(t *testing.T) {
+	if len(sessionSignals) == 0 {
+		t.Fatal("sessionSignals must contain at least one signal")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ignoreSessionSignals — cross-platform structural tests
+// ---------------------------------------------------------------------------
+
+// TestIgnoreSessionSignals_RestoreIsIdempotent ensures the restore closure is
+// safe to invoke more than once. Defers in some call paths can fire twice in
+// rare error-recovery scenarios, and signal.Reset is documented as a no-op
+// for unset signals.
+func TestIgnoreSessionSignals_RestoreIsIdempotent(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("calling restore twice panicked: %v", r)
+		}
+	}()
+
+	restore := ignoreSessionSignals()
+	restore()
+	restore()
+}
+
+// TestIgnoreSessionSignals_HelperReturnsFunction is a tiny structural test
+// that catches accidental nil returns from the helper, which would crash
+// runSessionManagerPlugin at `defer restore()` time.
+func TestIgnoreSessionSignals_HelperReturnsFunction(t *testing.T) {
+	restore := ignoreSessionSignals()
+	if restore == nil {
+		t.Fatal("ignoreSessionSignals returned nil restore func")
+	}
+	restore()
+}

--- a/internal/ssm/signals_unix.go
+++ b/internal/ssm/signals_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package ssm
+
+import (
+	"os"
+	"syscall"
+)
+
+// sessionSignals are the user-entered terminal control signals that ssmctl
+// must ignore while session-manager-plugin is the active foreground process.
+//
+// Rationale (see issue #85):
+//   - SIGINT  (Ctrl-C) — When the plugin is connected to an interactive shell
+//     it puts the terminal into raw mode, so Ctrl-C is sent through stdin as
+//     byte 0x03 and the remote PTY generates SIGINT for the remote process.
+//     If ssmctl (the parent) also receives SIGINT and exits, the plugin loses
+//     its controlling parent and stdin returns EIO, terminating the session
+//     instead of the long-running remote command.
+//   - SIGQUIT (Ctrl-\) — Same failure mode as SIGINT for an interactive
+//     session; must be delivered to the remote PTY only.
+//   - SIGTSTP (Ctrl-Z) — Suspending ssmctl while the plugin is attached to
+//     our TTY would orphan the plugin in the foreground process group and
+//     break stdin reads. We let the plugin manage suspension semantics.
+//
+// This mirrors aws-cli's `ignore_user_entered_signals()` in
+// awscli/customizations/sessionmanager.py.
+var sessionSignals = []os.Signal{
+	syscall.SIGINT,
+	syscall.SIGQUIT,
+	syscall.SIGTSTP,
+}

--- a/internal/ssm/signals_unix_test.go
+++ b/internal/ssm/signals_unix_test.go
@@ -1,0 +1,116 @@
+//go:build !windows
+
+package ssm
+
+import (
+	"os"
+	"os/signal"
+	"slices"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// ignoreSessionSignals — signal-delivery tests (POSIX only)
+// syscall.Kill and syscall.Getpid are not available on Windows.
+// ---------------------------------------------------------------------------
+
+// TestIgnoreSessionSignals_IgnoresSIGINT verifies that after the helper runs,
+// a SIGINT sent to the test process is silently discarded rather than killing
+// it. This is the precise scenario from issue #85: ssmctl must survive the
+// Ctrl-C that the user types while the plugin is forwarding signals to the
+// remote PTY.
+//
+// Mechanism: signal.Ignore installs SIG_IGN at the OS level, so the kernel
+// drops the signal at delivery time. Sending SIGINT to ourselves under
+// SIG_IGN is a true no-op, making this test safe to run in-process.
+func TestIgnoreSessionSignals_IgnoresSIGINT(t *testing.T) {
+	restore := ignoreSessionSignals()
+	defer restore()
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("kill self with SIGINT: %v", err)
+	}
+
+	// Give the kernel a beat to deliver the signal. If the helper failed to
+	// install SIG_IGN, the Go runtime's default SIGINT handler would have
+	// terminated the test binary by now.
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestIgnoreSessionSignals_RestoreAllowsDelivery verifies that after the
+// returned restore function is called, the default handler is reinstated so
+// subsequent signals are delivered normally.
+//
+// We assert this without letting SIGINT actually kill the test by registering
+// a Notify channel AFTER restore — if restore re-enabled signal delivery,
+// our channel will receive the signal.
+func TestIgnoreSessionSignals_RestoreAllowsDelivery(t *testing.T) {
+	restore := ignoreSessionSignals()
+	restore()
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT)
+	t.Cleanup(func() { signal.Stop(ch) })
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("kill self with SIGINT: %v", err)
+	}
+
+	select {
+	case got := <-ch:
+		if got != syscall.SIGINT {
+			t.Fatalf("received %v, want SIGINT", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SIGINT was not delivered after restore — signal handler was not reset")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sessionSignals list — POSIX-specific membership checks
+// ---------------------------------------------------------------------------
+
+// TestSessionSignals_UnixIncludesQuitAndTstp pins the POSIX signal list so
+// future edits cannot silently drop a signal that aws-cli's reference
+// implementation handles.
+func TestSessionSignals_UnixIncludesQuitAndTstp(t *testing.T) {
+	want := []os.Signal{
+		os.Signal(syscall.SIGINT),
+		os.Signal(syscall.SIGQUIT),
+		os.Signal(syscall.SIGTSTP),
+	}
+	for _, s := range want {
+		if !slices.Contains(sessionSignals, s) {
+			t.Errorf("sessionSignals missing %v on POSIX; got %v", s, sessionSignals)
+		}
+	}
+}
+
+// TestIgnoreSessionSignals_IgnoresSIGQUIT verifies the Ctrl-\ case. SIGQUIT's
+// default action is "core dump and terminate", so without SIG_IGN this test
+// would not finish.
+func TestIgnoreSessionSignals_IgnoresSIGQUIT(t *testing.T) {
+	restore := ignoreSessionSignals()
+	defer restore()
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGQUIT); err != nil {
+		t.Fatalf("kill self with SIGQUIT: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestIgnoreSessionSignals_IgnoresSIGTSTP verifies the Ctrl-Z case. SIGTSTP's
+// default action is "stop the process" — under SIG_IGN the test continues,
+// without it the test runner would hang. This is the strongest in-process
+// signal we can self-deliver to prove the helper is installed correctly.
+func TestIgnoreSessionSignals_IgnoresSIGTSTP(t *testing.T) {
+	restore := ignoreSessionSignals()
+	defer restore()
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTSTP); err != nil {
+		t.Fatalf("kill self with SIGTSTP: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+}

--- a/internal/ssm/signals_windows.go
+++ b/internal/ssm/signals_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package ssm
+
+import (
+	"os"
+	"syscall"
+)
+
+// sigBreak is the Go signal value that corresponds to Windows CTRL_BREAK_EVENT.
+// Go's runtime maps that console control event to syscall.Signal(0x15) — the
+// same value exported by golang.org/x/sys/windows as SIGBREAK. We define it
+// inline to avoid pulling in that module just for a single constant.
+const sigBreak = syscall.Signal(0x15)
+
+// sessionSignals are the user-entered console control signals that ssmctl
+// must ignore while session-manager-plugin is the active foreground process.
+//
+// On Windows, console control events surface in Go as:
+//   - CTRL_C_EVENT     → syscall.SIGINT  (Ctrl-C)
+//   - CTRL_BREAK_EVENT → sigBreak        (Ctrl-Break)
+//
+// SIGQUIT and SIGTSTP are POSIX-only and intentionally omitted.
+var sessionSignals = []os.Signal{
+	syscall.SIGINT,
+	sigBreak,
+}


### PR DESCRIPTION
…plugin subprocess

## Summary
This coveres all sig controls across win, linux and macos meaning subprocesses will be exited gracefully while user remains in long running remote session

## Related issue
fixes #85 

## What changed

-
-
-

## Testing performed
full testing has been covered


