### PR TITLE
fix: run command argv handling after --

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -45,7 +47,7 @@ ssmctl does not currently select automatically.`,
 			}
 
 			target := args[0]
-			command := args[dashAt:]
+			command := []string{joinShellArgs(args[dashAt:])}
 
 			targetInfo, err := ssmlib.ResolveTargetInfo(cmd.Context(), a.EC2Client, target)
 			if err != nil {
@@ -86,5 +88,38 @@ ssmctl does not currently select automatically.`,
 
 			return nil
 		},
+	}
+}
+
+func joinShellArgs(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellArg(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellArg(arg string) string {
+	if arg == "" {
+		return ssmlib.ShellQuote(arg)
+	}
+	for _, r := range arg {
+		if !isSafeShellRune(r) {
+			return ssmlib.ShellQuote(arg)
+		}
+	}
+	return arg
+}
+
+func isSafeShellRune(r rune) bool {
+	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		return true
+	}
+
+	switch r {
+	case '_', '@', '%', '+', '=', ':', ',', '.', '/', '-':
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -117,7 +117,7 @@ func isSafeShellRune(r rune) bool {
 	}
 
 	switch r {
-	case '_', '@', '%', '+', '=', ':', ',', '.', '/', '-':
+	case '_', '@', '%', '+', '=', ':', ',', '.', '/', '-', '~':
 		return true
 	default:
 		return false

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -242,6 +242,72 @@ func TestRunCmd_DebugFlagDoesNotBreakExecution(t *testing.T) {
 	}
 }
 
+func TestRunCmd_JoinsCommandArgsIntoSingleShellLine(t *testing.T) {
+	var gotCommands []string
+
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, in *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			gotCommands = append([]string(nil), in.Parameters["commands"]...)
+			return &awsssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-joined")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			return &awsssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusSuccess,
+				ResponseCode: 0,
+			}, nil
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Timeout: 30 * time.Second},
+		SSMClient: client,
+	}
+
+	if err := executeRunCmd(context.Background(), a, []string{"run", "i-123", "--", "df", "-h", "/"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"df -h /"}
+	if len(gotCommands) != len(want) || gotCommands[0] != want[0] {
+		t.Fatalf("commands = %#v, want %#v", gotCommands, want)
+	}
+}
+
+func TestRunCmd_QuotesGroupedAndEmbeddedQuoteArgs(t *testing.T) {
+	var gotCommands []string
+
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, in *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			gotCommands = append([]string(nil), in.Parameters["commands"]...)
+			return &awsssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-quoted")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			return &awsssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusSuccess,
+				ResponseCode: 0,
+			}, nil
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Timeout: 30 * time.Second},
+		SSMClient: client,
+	}
+
+	if err := executeRunCmd(context.Background(), a, []string{"run", "i-123", "--", "printf", "%s", "hello world", "it's"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{`printf %s 'hello world' 'it'\''s'`}
+	if len(gotCommands) != len(want) || gotCommands[0] != want[0] {
+		t.Fatalf("commands = %#v, want %#v", gotCommands, want)
+	}
+}
+
 func TestRunCmd_WindowsTargetReturnsError(t *testing.T) {
 	ec2Client := &mockEC2CmdClient{
 		fn: func(_ context.Context, _ *awsec2.DescribeInstancesInput, _ ...func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -308,6 +308,39 @@ func TestRunCmd_QuotesGroupedAndEmbeddedQuoteArgs(t *testing.T) {
 	}
 }
 
+func TestRunCmd_PreservesTildePrefixWithoutQuoting(t *testing.T) {
+	var gotCommands []string
+
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, in *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			gotCommands = append([]string(nil), in.Parameters["commands"]...)
+			return &awsssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-tilde")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			return &awsssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusSuccess,
+				ResponseCode: 0,
+			}, nil
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Timeout: 30 * time.Second},
+		SSMClient: client,
+	}
+
+	if err := executeRunCmd(context.Background(), a, []string{"run", "i-123", "--", "cat", "~/logs/app.log"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"cat ~/logs/app.log"}
+	if len(gotCommands) != len(want) || gotCommands[0] != want[0] {
+		t.Fatalf("commands = %#v, want %#v", gotCommands, want)
+	}
+}
+
 func TestRunCmd_WindowsTargetReturnsError(t *testing.T) {
 	ec2Client := &mockEC2CmdClient{
 		fn: func(_ context.Context, _ *awsec2.DescribeInstancesInput, _ ...func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {


### PR DESCRIPTION
## Summary
- rebuild the argv after -- into a single shell command before calling AWS-RunShellScript
- shell-quote arguments when needed so grouped values and embedded quotes survive the round trip
- add cmd-layer regression tests that assert the exact commands payload sent to SSM

## Testing
- go test ./internal/cmd -run TestRunCmd -count=1
- go test ./internal/ssm -count=1
- go test ./... -count=1

Fixes #91