### PR TITLE
feat: support Windows targets for run and cp

### DIFF
--- a/benchmarks/transfer_bench_test.go
+++ b/benchmarks/transfer_bench_test.go
@@ -71,7 +71,7 @@ func benchmarkUpload(b *testing.B, size int) {
 	for i := 0; i < b.N; i++ {
 		localFile := writeTemp(b, size)
 		dst := filepath.Join(b.TempDir(), "dst.bin")
-		_, err := ssmlib.Upload(context.Background(), client, "i-bench", localFile, dst, 30*time.Second)
+		_, err := ssmlib.Upload(context.Background(), client, ssmlib.TargetInfo{InstanceID: "i-bench"}, localFile, dst, 30*time.Second)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -91,7 +91,7 @@ func benchmarkDownload(b *testing.B, size int) {
 	client := &benchSSMClient{stdout: encoded}
 	for i := 0; i < b.N; i++ {
 		dst := filepath.Join(b.TempDir(), "download.bin")
-		_, err := ssmlib.Download(context.Background(), client, "i-bench", "/remote/file.bin", dst, 30*time.Second)
+		_, err := ssmlib.Download(context.Background(), client, ssmlib.TargetInfo{InstanceID: "i-bench"}, "/remote/file.bin", dst, 30*time.Second)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -134,7 +134,7 @@ ssmctl run <target> -- <command> [args...]
 
 The `--` separator is required. Stdout and stderr are streamed to your terminal. The remote exit code is propagated.
 
-> **Note:** `run` targets Linux/macOS instances only. It uses `AWS-RunShellScript` internally. Windows targets require `AWS-RunPowerShellScript`, which is not yet supported.
+`run` uses `AWS-RunShellScript` for Linux/macOS targets and `AWS-RunPowerShellScript` for Windows targets.
 
 ### Flags
 
@@ -157,11 +157,14 @@ ssmctl run web-1 -t 5m -- /opt/app/migrate.sh
 
 # Capture as JSON for scripting
 ssmctl run web-1 --output json -- whoami
+
+# Run a PowerShell command on a Windows instance
+ssmctl run win-app-1 -- Get-Process
 ```
 
 ### Required IAM permissions
 
-- `ssm:SendCommand` with `AWS-RunShellScript`
+- `ssm:SendCommand` with `AWS-RunShellScript` and/or `AWS-RunPowerShellScript`
 - `ssm:GetCommandInvocation`
 
 ---
@@ -180,7 +183,7 @@ ssmctl cp <target>:<remote-path> <local-path>
 
 Remote paths use the `<target>:/path` syntax, where `<target>` is an instance ID or Name tag.
 
-> **Note:** `cp` targets Linux/macOS instances only. Transfers use `cat` and `base64` under the hood. Windows targets are not currently supported.
+Linux/macOS targets use POSIX shell utilities under the hood. Windows targets use PowerShell for in-band transfers. The S3-backed path requires the AWS CLI on the instance.
 
 ### Size limits (in-band SSM)
 
@@ -199,6 +202,9 @@ ssmctl cp ./nginx.conf web-1:/etc/nginx/nginx.conf
 
 # Download a log file
 ssmctl cp web-1:/var/log/app.log ./app.log
+
+# Upload to a Windows target
+ssmctl cp .\appsettings.json win-app-1:C:\Temp\appsettings.json
 ```
 
 **Windows host — drive-letter paths are supported:**
@@ -213,7 +219,7 @@ ssmctl cp web-1:/var/log/app.log C:\Users\Admin\logs\app.log
 
 ### Required IAM permissions
 
-- `ssm:SendCommand` with `AWS-RunShellScript`
+- `ssm:SendCommand` with `AWS-RunShellScript` and/or `AWS-RunPowerShellScript`
 - `ssm:GetCommandInvocation`
 
 ---
@@ -351,7 +357,9 @@ If a Name tag matches more than one running instance, `ssmctl` returns an error 
 | `list` | Supported | Supported |
 | `connect` | Supported | Supported |
 | `forward` | Supported | Supported |
-| `run` | Supported | Not supported — requires `AWS-RunPowerShellScript` |
-| `cp` | Supported | Not supported — requires POSIX utilities on the instance |
+| `run` | Supported | Supported |
+| `cp` | Supported | Supported |
 | `version` | Supported | Supported |
 | `completion` | Supported | Supported |
+
+

--- a/docs/iam.md
+++ b/docs/iam.md
@@ -70,7 +70,7 @@ ec2:DescribeInstances          (for Name tag resolution)
 ### `ssmctl run`
 
 ```
-ssm:SendCommand                (document: AWS-RunShellScript)
+ssm:SendCommand                (document: AWS-RunShellScript or AWS-RunPowerShellScript)
 ssm:GetCommandInvocation
 ec2:DescribeInstances          (for Name tag resolution)
 ```
@@ -78,7 +78,7 @@ ec2:DescribeInstances          (for Name tag resolution)
 ### `ssmctl cp` (in-band, no S3)
 
 ```
-ssm:SendCommand                (document: AWS-RunShellScript)
+ssm:SendCommand                (document: AWS-RunShellScript or AWS-RunPowerShellScript)
 ssm:GetCommandInvocation
 ec2:DescribeInstances          (for Name tag resolution)
 ```
@@ -90,7 +90,7 @@ The S3-backed transfer path requires permissions on **both** the caller's identi
 **Caller identity (the person running ssmctl):**
 
 ```
-ssm:SendCommand                (document: AWS-RunShellScript)
+ssm:SendCommand                (document: AWS-RunShellScript or AWS-RunPowerShellScript)
 ssm:GetCommandInvocation
 ec2:DescribeInstances
 s3:PutObject                   (upload: caller stages the file)

--- a/e2e/aws_test.go
+++ b/e2e/aws_test.go
@@ -3,9 +3,11 @@
 // AWS integration tests — require real AWS credentials and a running EC2
 // instance with the SSM Agent installed.
 //
-// Set the following environment variable before running:
+// Set the following environment variables before running:
 //
-//	E2E_INSTANCE_ID   — instance ID to target (e.g. i-0123456789abcdef0)
+//	E2E_INSTANCE_ID           — Linux/macOS instance ID to target (e.g. i-0123456789abcdef0)
+//	E2E_WINDOWS_INSTANCE_ID   — Windows instance ID to target
+//	E2E_S3_STAGING_URL        — s3://bucket[/prefix] used for staged transfer tests
 //
 // Region, profile, and all other AWS configuration are picked up from the
 // standard AWS environment variables (AWS_DEFAULT_REGION, AWS_PROFILE, etc.)
@@ -20,6 +22,7 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -32,6 +35,24 @@ func instanceID(t *testing.T) string {
 		t.Skip("E2E_INSTANCE_ID not set — skipping AWS integration test")
 	}
 	return id
+}
+
+func windowsInstanceID(t *testing.T) string {
+	t.Helper()
+	id := os.Getenv("E2E_WINDOWS_INSTANCE_ID")
+	if id == "" {
+		t.Skip("E2E_WINDOWS_INSTANCE_ID not set — skipping Windows AWS integration test")
+	}
+	return id
+}
+
+func stagingURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("E2E_S3_STAGING_URL")
+	if url == "" {
+		t.Skip("E2E_S3_STAGING_URL not set — skipping S3-backed AWS integration test")
+	}
+	return url
 }
 
 // ---------------------------------------------------------------------------
@@ -65,6 +86,18 @@ func TestAWS_Run_Stderr(t *testing.T) {
 	_, err := run("run", id, "--", "sh", "-c", "echo err >&2; exit 1")
 	if err == nil {
 		t.Fatal("expected non-zero exit, got nil")
+	}
+}
+
+func TestAWS_Run_WindowsPowerShell(t *testing.T) {
+	id := windowsInstanceID(t)
+
+	out, err := run("run", id, "--", "Write-Output", "ssmctl-windows-e2e-ok")
+	if err != nil {
+		t.Fatalf("run windows powershell failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "ssmctl-windows-e2e-ok") {
+		t.Errorf("expected 'ssmctl-windows-e2e-ok' in output:\n%s", out)
 	}
 }
 
@@ -114,3 +147,63 @@ func TestAWS_Cp_DownloadNonExistentFile(t *testing.T) {
 		t.Fatal("expected error when downloading non-existent remote file, got nil")
 	}
 }
+
+func TestAWS_Cp_WindowsUploadAndDownload(t *testing.T) {
+	id := windowsInstanceID(t)
+
+	content := fmt.Sprintf("ssmctl-e2e-win-upload-%d", os.Getpid())
+	localSrc := filepath.Join(t.TempDir(), "upload.txt")
+	localDst := filepath.Join(t.TempDir(), "download.txt")
+	remotePath := `C:\Windows\Temp\ssmctl-e2e-upload.txt`
+
+	if err := os.WriteFile(localSrc, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if out, err := run("cp", localSrc, fmt.Sprintf("%s:%s", id, remotePath)); err != nil {
+		t.Fatalf("windows upload failed: %v\noutput: %s", err, out)
+	}
+
+	if out, err := run("cp", fmt.Sprintf("%s:%s", id, remotePath), localDst); err != nil {
+		t.Fatalf("windows download failed: %v\noutput: %s", err, out)
+	}
+
+	got, err := os.ReadFile(localDst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Errorf("downloaded content = %q, want %q", string(got), content)
+	}
+}
+
+func TestAWS_Cp_WindowsUploadAndDownloadViaS3(t *testing.T) {
+	id := windowsInstanceID(t)
+	via := stagingURL(t)
+
+	content := fmt.Sprintf("ssmctl-e2e-win-s3-%d", os.Getpid())
+	localSrc := filepath.Join(t.TempDir(), "upload.txt")
+	localDst := filepath.Join(t.TempDir(), "download.txt")
+	remotePath := `C:\Windows\Temp\ssmctl-e2e-s3.txt`
+
+	if err := os.WriteFile(localSrc, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if out, err := run("cp", "--via", via, localSrc, fmt.Sprintf("%s:%s", id, remotePath)); err != nil {
+		t.Fatalf("windows s3 upload failed: %v\noutput: %s", err, out)
+	}
+
+	if out, err := run("cp", "--via", via, fmt.Sprintf("%s:%s", id, remotePath), localDst); err != nil {
+		t.Fatalf("windows s3 download failed: %v\noutput: %s", err, out)
+	}
+
+	got, err := os.ReadFile(localDst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Errorf("downloaded content = %q, want %q", string(got), content)
+	}
+}
+

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -38,7 +38,7 @@ func TestHelp_RunSubcommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run --help exited with error: %v\noutput: %s", err, out)
 	}
-	for _, want := range []string{"run", "Linux/macOS targets", "AWS-RunPowerShellScript"} {
+	for _, want := range []string{"run", "AWS-RunShellScript", "AWS-RunPowerShellScript"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("run --help output missing %q:\n%s", want, out)
 		}
@@ -50,7 +50,7 @@ func TestHelp_CpSubcommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cp --help exited with error: %v\noutput: %s", err, out)
 	}
-	for _, want := range []string{"cp", "Linux/macOS targets only", "POSIX utilities", "--via", "--keep-staging"} {
+	for _, want := range []string{"cp", "Windows targets", "PowerShell", "--via", "--keep-staging"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("cp --help output missing %q:\n%s", want, out)
 		}

--- a/internal/cmd/cp.go
+++ b/internal/cmd/cp.go
@@ -32,11 +32,9 @@ Download: ssmctl cp my-server:/var/log/app.log ./app.log
 Note: in-band SSM transfers are limited to ~2MB uploads and ~36KB downloads.
 Use --via s3://bucket/prefix to stage the file in S3 and lift those limits.
 
-Remote copy support is for Linux/macOS targets only. Uploads and downloads
-construct remote shell commands that depend on POSIX utilities such as cat and
-base64, which are not available by default on Windows targets. The S3-backed
-path additionally requires the AWS CLI on the instance and S3 access from the
-instance role.`,
+Linux/macOS targets use POSIX shell utilities under the hood. Windows targets
+use PowerShell for in-band transfers and require the AWS CLI on the instance
+for the S3-backed path.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a := cmd.Context().Value(app.ContextKey{}).(*app.App)
@@ -66,13 +64,10 @@ instance role.`,
 				if resolveErr != nil {
 					return fmt.Errorf("resolve source instance: %w", resolveErr)
 				}
-				if target.IsWindows() {
-					return fmt.Errorf("cp does not currently support Windows targets; remote copy relies on POSIX utilities such as cat and base64")
-				}
 				if useS3 {
-					result, err = ssmlib.DownloadViaS3(cmd.Context(), a.SSMClient, a.S3Client, target.InstanceID, srcPath, dstPath, staging, opts.keepStaging, a.Config.Timeout)
+					result, err = ssmlib.DownloadViaS3(cmd.Context(), a.SSMClient, a.S3Client, target, srcPath, dstPath, staging, opts.keepStaging, a.Config.Timeout)
 				} else {
-					result, err = ssmlib.Download(cmd.Context(), a.SSMClient, target.InstanceID, srcPath, dstPath, a.Config.Timeout)
+					result, err = ssmlib.Download(cmd.Context(), a.SSMClient, target, srcPath, dstPath, a.Config.Timeout)
 				}
 
 			case !srcRemote && dstRemote:
@@ -80,13 +75,10 @@ instance role.`,
 				if resolveErr != nil {
 					return fmt.Errorf("resolve destination instance: %w", resolveErr)
 				}
-				if target.IsWindows() {
-					return fmt.Errorf("cp does not currently support Windows targets; remote copy relies on POSIX utilities such as cat and base64")
-				}
 				if useS3 {
-					result, err = ssmlib.UploadViaS3(cmd.Context(), a.SSMClient, a.S3Client, target.InstanceID, srcPath, dstPath, staging, opts.keepStaging, a.Config.Timeout)
+					result, err = ssmlib.UploadViaS3(cmd.Context(), a.SSMClient, a.S3Client, target, srcPath, dstPath, staging, opts.keepStaging, a.Config.Timeout)
 				} else {
-					result, err = ssmlib.Upload(cmd.Context(), a.SSMClient, target.InstanceID, srcPath, dstPath, a.Config.Timeout)
+					result, err = ssmlib.Upload(cmd.Context(), a.SSMClient, target, srcPath, dstPath, a.Config.Timeout)
 				}
 
 			default:

--- a/internal/cmd/cp_test.go
+++ b/internal/cmd/cp_test.go
@@ -395,6 +395,71 @@ func TestCpCmd_DownloadViaS3RoutesThroughS3Path(t *testing.T) {
 	}
 }
 
+func TestCpCmd_WindowsDownloadViaS3UsesPowerShellDocument(t *testing.T) {
+	ssmlib.SetPollInterval(10 * time.Millisecond)
+	t.Cleanup(func() { ssmlib.SetPollInterval(2 * time.Second) })
+
+	var gotDocument string
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, in *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			gotDocument = aws.ToString(in.DocumentName)
+			return &awsssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-win-dl-s3")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			return &awsssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusSuccess,
+				ResponseCode: 0,
+			}, nil
+		},
+	}
+
+	ec2Client := &mockEC2CmdClient{
+		fn: func(_ context.Context, _ *awsec2.DescribeInstancesInput, _ ...func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {
+			return &awsec2.DescribeInstancesOutput{
+				Reservations: []ec2types.Reservation{
+					{
+						Instances: []ec2types.Instance{
+							{
+								InstanceId: aws.String("i-win-dl"),
+								Platform:   ec2types.PlatformValuesWindows,
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	s3Client := &mockS3CmdClient{
+		getObjectFn: func(_ context.Context, in *s3.GetObjectInput) ([]byte, error) {
+			if aws.ToString(in.Bucket) != "bucket" {
+				t.Fatalf("GetObject bucket = %q, want %q", aws.ToString(in.Bucket), "bucket")
+			}
+			return []byte("windows download via s3"), nil
+		},
+	}
+
+	localFile := filepath.Join(t.TempDir(), "download.txt")
+	a := &app.App{
+		Config:    &config.Config{Output: "json", Timeout: 30 * time.Second},
+		SSMClient: client,
+		EC2Client: ec2Client,
+		S3Client:  s3Client,
+		Printer:   &output.Printer{Format: "json"},
+	}
+
+	var buf bytes.Buffer
+	if err := executeCpCmdWithOutput(context.Background(), a, []string{"cp", "--via", "s3://bucket/tmp", `i-win-dl:C:\Temp\file.txt`, localFile}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotDocument != "AWS-RunPowerShellScript" {
+		t.Fatalf("DocumentName = %q, want %q", gotDocument, "AWS-RunPowerShellScript")
+	}
+}
+
 func TestCpCmd_HelpMentionsWindowsTargetSupport(t *testing.T) {
 	out := cpCmd().Long
 	for _, want := range []string{"Windows targets", "PowerShell", "AWS CLI"} {

--- a/internal/cmd/cp_test.go
+++ b/internal/cmd/cp_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/spf13/cobra"
@@ -35,6 +37,12 @@ func executeCpCmdWithOutput(ctx context.Context, a *app.App, args []string, buf 
 	return root.ExecuteContext(context.WithValue(ctx, app.ContextKey{}, a)) //nolint:wrapcheck
 }
 
+type mockS3CmdClient struct {
+	putObjectFn    func(context.Context, *s3.PutObjectInput) error
+	getObjectFn    func(context.Context, *s3.GetObjectInput) ([]byte, error)
+	deleteObjectFn func(context.Context, *s3.DeleteObjectInput) error
+}
+
 func alwaysSucceedSSMClient() *mockSSMCmdClient {
 	return &mockSSMCmdClient{
 		sendCommandFn: func(_ context.Context, _ *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
@@ -50,6 +58,35 @@ func alwaysSucceedSSMClient() *mockSSMCmdClient {
 			}, nil
 		},
 	}
+}
+
+func (m *mockS3CmdClient) PutObject(ctx context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if m.putObjectFn != nil {
+		if err := m.putObjectFn(ctx, in); err != nil {
+			return nil, err
+		}
+	}
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (m *mockS3CmdClient) GetObject(ctx context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if m.getObjectFn != nil {
+		body, err := m.getObjectFn(ctx, in)
+		if err != nil {
+			return nil, err
+		}
+		return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(body))}, nil
+	}
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(nil))}, nil
+}
+
+func (m *mockS3CmdClient) DeleteObject(ctx context.Context, in *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	if m.deleteObjectFn != nil {
+		if err := m.deleteObjectFn(ctx, in); err != nil {
+			return nil, err
+		}
+	}
+	return &s3.DeleteObjectOutput{}, nil
 }
 
 func TestCpCmd_UploadJSONOutput(t *testing.T) {
@@ -279,6 +316,82 @@ func TestCpCmd_WindowsUploadUsesPowerShellDocument(t *testing.T) {
 
 	if gotDocument != "AWS-RunPowerShellScript" {
 		t.Fatalf("DocumentName = %q, want %q", gotDocument, "AWS-RunPowerShellScript")
+	}
+}
+
+func TestCpCmd_UploadViaS3RoutesThroughS3Path(t *testing.T) {
+	ssmlib.SetPollInterval(10 * time.Millisecond)
+	t.Cleanup(func() { ssmlib.SetPollInterval(2 * time.Second) })
+
+	localFile := filepath.Join(t.TempDir(), "upload.txt")
+	if err := os.WriteFile(localFile, []byte("hello via s3"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	client := alwaysSucceedSSMClient()
+	s3Client := &mockS3CmdClient{
+		putObjectFn: func(_ context.Context, in *s3.PutObjectInput) error {
+			if aws.ToString(in.Bucket) != "bucket" {
+				t.Fatalf("PutObject bucket = %q, want %q", aws.ToString(in.Bucket), "bucket")
+			}
+			return nil
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Output: "json", Timeout: 30 * time.Second},
+		SSMClient: client,
+		S3Client:  s3Client,
+		Printer:   &output.Printer{Format: "json"},
+	}
+
+	var buf bytes.Buffer
+	if err := executeCpCmdWithOutput(context.Background(), a, []string{"cp", "--via", "s3://bucket/tmp", localFile, "i-123:/tmp/upload.txt"}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got ssmlib.TransferResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw: %s", err, buf.String())
+	}
+	if got.Via != "s3" {
+		t.Fatalf("Via = %q, want %q", got.Via, "s3")
+	}
+}
+
+func TestCpCmd_DownloadViaS3RoutesThroughS3Path(t *testing.T) {
+	ssmlib.SetPollInterval(10 * time.Millisecond)
+	t.Cleanup(func() { ssmlib.SetPollInterval(2 * time.Second) })
+
+	client := alwaysSucceedSSMClient()
+	s3Client := &mockS3CmdClient{
+		getObjectFn: func(_ context.Context, in *s3.GetObjectInput) ([]byte, error) {
+			if aws.ToString(in.Bucket) != "bucket" {
+				t.Fatalf("GetObject bucket = %q, want %q", aws.ToString(in.Bucket), "bucket")
+			}
+			return []byte("downloaded via s3"), nil
+		},
+	}
+
+	localFile := filepath.Join(t.TempDir(), "download.txt")
+	a := &app.App{
+		Config:    &config.Config{Output: "json", Timeout: 30 * time.Second},
+		SSMClient: client,
+		S3Client:  s3Client,
+		Printer:   &output.Printer{Format: "json"},
+	}
+
+	var buf bytes.Buffer
+	if err := executeCpCmdWithOutput(context.Background(), a, []string{"cp", "--via", "s3://bucket/tmp", "i-123:/remote/file.txt", localFile}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got ssmlib.TransferResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw: %s", err, buf.String())
+	}
+	if got.Via != "s3" {
+		t.Fatalf("Via = %q, want %q", got.Via, "s3")
 	}
 }
 

--- a/internal/cmd/cp_test.go
+++ b/internal/cmd/cp_test.go
@@ -7,10 +7,13 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/spf13/cobra"
@@ -217,5 +220,73 @@ func TestCpCmd_UploadTextOutputSilent(t *testing.T) {
 	}
 	if buf.Len() != 0 {
 		t.Errorf("expected no output for text format, got: %s", buf.String())
+	}
+}
+
+func TestCpCmd_WindowsUploadUsesPowerShellDocument(t *testing.T) {
+	ssmlib.SetPollInterval(10 * time.Millisecond)
+	t.Cleanup(func() { ssmlib.SetPollInterval(2 * time.Second) })
+
+	localFile := filepath.Join(t.TempDir(), "upload.txt")
+	if err := os.WriteFile(localFile, []byte("hello windows cp"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotDocument string
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, in *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			gotDocument = aws.ToString(in.DocumentName)
+			return &awsssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-win-cp")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			return &awsssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusSuccess,
+				ResponseCode: 0,
+			}, nil
+		},
+	}
+
+	ec2Client := &mockEC2CmdClient{
+		fn: func(_ context.Context, _ *awsec2.DescribeInstancesInput, _ ...func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {
+			return &awsec2.DescribeInstancesOutput{
+				Reservations: []ec2types.Reservation{
+					{
+						Instances: []ec2types.Instance{
+							{
+								InstanceId: aws.String("i-wincp"),
+								Platform:   ec2types.PlatformValuesWindows,
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Output: "json", Timeout: 30 * time.Second},
+		SSMClient: client,
+		EC2Client: ec2Client,
+		Printer:   &output.Printer{Format: "json"},
+	}
+
+	var buf bytes.Buffer
+	if err := executeCpCmdWithOutput(context.Background(), a, []string{"cp", localFile, `i-wincp:C:\Temp\upload.txt`}, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotDocument != "AWS-RunPowerShellScript" {
+		t.Fatalf("DocumentName = %q, want %q", gotDocument, "AWS-RunPowerShellScript")
+	}
+}
+
+func TestCpCmd_HelpMentionsWindowsTargetSupport(t *testing.T) {
+	out := cpCmd().Long
+	for _, want := range []string{"Windows targets", "PowerShell", "AWS CLI"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("cp help text missing %q:\n%s", want, out)
+		}
 	}
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -33,9 +33,8 @@ func runCmd() *cobra.Command {
 		Short: "Execute a command on a target instance via SSM",
 		Long: `Execute a command on a target instance via SSM.
 
-The run command uses the AWS-RunShellScript document and is intended for
-Linux/macOS targets. Windows targets require AWS-RunPowerShellScript, which
-ssmctl does not currently select automatically.`,
+The run command uses AWS-RunShellScript for Linux/macOS targets and
+AWS-RunPowerShellScript for Windows targets.`,
 		Args:               cobra.MinimumNArgs(1),
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -47,17 +46,17 @@ ssmctl does not currently select automatically.`,
 			}
 
 			target := args[0]
-			command := []string{joinShellArgs(args[dashAt:])}
 
 			targetInfo, err := ssmlib.ResolveTargetInfo(cmd.Context(), a.EC2Client, target)
 			if err != nil {
 				return fmt.Errorf("resolve target: %w", err)
 			}
+			command := []string{joinShellArgs(args[dashAt:])}
 			if targetInfo.IsWindows() {
-				return fmt.Errorf("run does not currently support Windows targets; Windows targets require AWS-RunPowerShellScript, which ssmctl does not currently select automatically")
+				command = []string{joinPowerShellArgs(args[dashAt:])}
 			}
 
-			result, err := ssmlib.RunCommand(cmd.Context(), a.SSMClient, targetInfo.InstanceID, command, a.Config.Timeout)
+			result, err := ssmlib.RunCommandForTarget(cmd.Context(), a.SSMClient, targetInfo, command, a.Config.Timeout)
 			if err != nil {
 				return fmt.Errorf("run command: %w", err)
 			}
@@ -92,9 +91,26 @@ ssmctl does not currently select automatically.`,
 }
 
 func joinShellArgs(args []string) string {
+	return joinArgs(args, shellArg)
+}
+
+func joinPowerShellArgs(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+
+	quoted := make([]string, 0, len(args))
+	quoted = append(quoted, powerShellCommandName(args[0]))
+	for _, arg := range args[1:] {
+		quoted = append(quoted, powerShellArg(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func joinArgs(args []string, quote func(string) string) string {
 	quoted := make([]string, 0, len(args))
 	for _, arg := range args {
-		quoted = append(quoted, shellArg(arg))
+		quoted = append(quoted, quote(arg))
 	}
 	return strings.Join(quoted, " ")
 }
@@ -111,6 +127,30 @@ func shellArg(arg string) string {
 	return arg
 }
 
+func powerShellArg(arg string) string {
+	if arg == "" {
+		return ssmlib.PowerShellQuote(arg)
+	}
+	for _, r := range arg {
+		if !isSafePowerShellRune(r) {
+			return ssmlib.PowerShellQuote(arg)
+		}
+	}
+	return arg
+}
+
+func powerShellCommandName(arg string) string {
+	if arg == "" {
+		return "& " + ssmlib.PowerShellQuote(arg)
+	}
+	for _, r := range arg {
+		if !isSafePowerShellRune(r) {
+			return "& " + ssmlib.PowerShellQuote(arg)
+		}
+	}
+	return arg
+}
+
 func isSafeShellRune(r rune) bool {
 	if unicode.IsLetter(r) || unicode.IsDigit(r) {
 		return true
@@ -118,6 +158,19 @@ func isSafeShellRune(r rune) bool {
 
 	switch r {
 	case '_', '@', '%', '+', '=', ':', ',', '.', '/', '-', '~':
+		return true
+	default:
+		return false
+	}
+}
+
+func isSafePowerShellRune(r rune) bool {
+	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		return true
+	}
+
+	switch r {
+	case '_', '@', '%', '+', '=', ':', ',', '.', '/', '\\', '-', '~':
 		return true
 	default:
 		return false

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -170,7 +170,7 @@ func isSafePowerShellRune(r rune) bool {
 	}
 
 	switch r {
-	case '_', '@', '%', '+', '=', ':', ',', '.', '/', '\\', '-', '~':
+	case '_', '%', '+', '=', ':', ',', '.', '/', '\\', '-', '~':
 		return true
 	default:
 		return false

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,6 +107,27 @@ func TestRunCmd_MissingDashDashReturnsError(t *testing.T) {
 	err := executeRunCmd(context.Background(), a, []string{"run", "i-123"})
 	if err == nil {
 		t.Fatal("expected error for missing --, got nil")
+	}
+}
+
+func TestRunCmd_ResolveTargetErrorIsWrapped(t *testing.T) {
+	ec2Client := &mockEC2CmdClient{
+		fn: func(_ context.Context, _ *awsec2.DescribeInstancesInput, _ ...func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {
+			return nil, errors.New("ec2 unavailable")
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Timeout: 30 * time.Second},
+		EC2Client: ec2Client,
+	}
+
+	err := executeRunCmd(context.Background(), a, []string{"run", "named-target", "--", "echo", "hi"})
+	if err == nil {
+		t.Fatal("expected resolve target error, got nil")
+	}
+	if !strings.Contains(err.Error(), "resolve target") {
+		t.Fatalf("error = %q, want wrapped resolve target message", err.Error())
 	}
 }
 
@@ -238,6 +260,31 @@ func TestRunCmd_DebugFlagDoesNotBreakExecution(t *testing.T) {
 	err := executeRunCmd(context.Background(), a, []string{"run", "i-123", "--", "echo", "hi"})
 	if err != nil {
 		t.Fatalf("expected no error with debug flag, got %v", err)
+	}
+}
+
+func TestRunCmd_RunCommandErrorIsWrapped(t *testing.T) {
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, _ *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			return nil, errors.New("send failed")
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			t.Fatal("GetCommandInvocation should not be called when SendCommand fails")
+			return nil, nil
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Timeout: 30 * time.Second},
+		SSMClient: client,
+	}
+
+	err := executeRunCmd(context.Background(), a, []string{"run", "i-123", "--", "echo", "hi"})
+	if err == nil {
+		t.Fatal("expected run command error, got nil")
+	}
+	if !strings.Contains(err.Error(), "run command") {
+		t.Fatalf("error = %q, want wrapped run command message", err.Error())
 	}
 }
 

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -350,6 +350,12 @@ func TestPowerShellArg_SafeString(t *testing.T) {
 	}
 }
 
+func TestPowerShellArg_QuotesAtPrefixedString(t *testing.T) {
+	if got := powerShellArg("@hash"); got != "'@hash'" {
+		t.Fatalf("powerShellArg() = %q, want %q", got, "'@hash'")
+	}
+}
+
 func TestPowerShellCommandName_EmptyString(t *testing.T) {
 	if got := powerShellCommandName(""); got != "& ''" {
 		t.Fatalf("powerShellCommandName(\"\") = %q, want %q", got, "& ''")

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -274,6 +274,35 @@ func TestRunCmd_JoinsCommandArgsIntoSingleShellLine(t *testing.T) {
 	}
 }
 
+func TestJoinPowerShellArgs_Empty(t *testing.T) {
+	if got := joinPowerShellArgs(nil); got != "" {
+		t.Fatalf("joinPowerShellArgs(nil) = %q, want empty string", got)
+	}
+}
+
+func TestJoinPowerShellArgs_QuotesUnsafeCommandName(t *testing.T) {
+	got := joinPowerShellArgs([]string{`C:\Program Files\Tool\tool.exe`, "arg value"})
+	want := `& 'C:\Program Files\Tool\tool.exe' 'arg value'`
+	if got != want {
+		t.Fatalf("joinPowerShellArgs() = %q, want %q", got, want)
+	}
+}
+
+func TestShellAndPowerShellArg_EmptyString(t *testing.T) {
+	if got := shellArg(""); got != "''" {
+		t.Fatalf("shellArg(\"\") = %q, want %q", got, "''")
+	}
+	if got := powerShellArg(""); got != "''" {
+		t.Fatalf("powerShellArg(\"\") = %q, want %q", got, "''")
+	}
+}
+
+func TestPowerShellCommandName_EmptyString(t *testing.T) {
+	if got := powerShellCommandName(""); got != "& ''" {
+		t.Fatalf("powerShellCommandName(\"\") = %q, want %q", got, "& ''")
+	}
+}
+
 func TestRunCmd_QuotesGroupedAndEmbeddedQuoteArgs(t *testing.T) {
 	var gotCommands []string
 

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -344,6 +344,12 @@ func TestShellAndPowerShellArg_EmptyString(t *testing.T) {
 	}
 }
 
+func TestPowerShellArg_SafeString(t *testing.T) {
+	if got := powerShellArg("Get-Process"); got != "Get-Process" {
+		t.Fatalf("powerShellArg() = %q, want %q", got, "Get-Process")
+	}
+}
+
 func TestPowerShellCommandName_EmptyString(t *testing.T) {
 	if got := powerShellCommandName(""); got != "& ''" {
 		t.Fatalf("powerShellCommandName(\"\") = %q, want %q", got, "& ''")

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -341,7 +340,26 @@ func TestRunCmd_PreservesTildePrefixWithoutQuoting(t *testing.T) {
 	}
 }
 
-func TestRunCmd_WindowsTargetReturnsError(t *testing.T) {
+func TestRunCmd_WindowsTargetUsesPowerShellDocument(t *testing.T) {
+	var gotDocument string
+	var gotCommands []string
+
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, in *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			gotDocument = aws.ToString(in.DocumentName)
+			gotCommands = append([]string(nil), in.Parameters["commands"]...)
+			return &awsssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-win")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			return &awsssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusSuccess,
+				ResponseCode: 0,
+			}, nil
+		},
+	}
+
 	ec2Client := &mockEC2CmdClient{
 		fn: func(_ context.Context, _ *awsec2.DescribeInstancesInput, _ ...func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {
 			return &awsec2.DescribeInstancesOutput{
@@ -361,15 +379,72 @@ func TestRunCmd_WindowsTargetReturnsError(t *testing.T) {
 
 	a := &app.App{
 		Config:    &config.Config{Timeout: 30 * time.Second},
+		SSMClient: client,
 		EC2Client: ec2Client,
 	}
 
-	err := executeRunCmd(context.Background(), a, []string{"run", "i-wintest", "--", "dir"})
-	if err == nil {
-		t.Fatal("expected error for Windows target, got nil")
+	err := executeRunCmd(context.Background(), a, []string{"run", "i-wintest", "--", "Write-Output", "hello world", "it's"})
+	if err != nil {
+		t.Fatalf("expected Windows target to run, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "Windows") {
-		t.Errorf("error should mention Windows, got: %v", err)
+	if gotDocument != "AWS-RunPowerShellScript" {
+		t.Fatalf("DocumentName = %q, want %q", gotDocument, "AWS-RunPowerShellScript")
+	}
+	wantCommands := []string{`Write-Output 'hello world' 'it''s'`}
+	if len(gotCommands) != len(wantCommands) || gotCommands[0] != wantCommands[0] {
+		t.Fatalf("commands = %#v, want %#v", gotCommands, wantCommands)
+	}
+}
+
+func TestRunCmd_WindowsTargetQuotesCommandPathWithSpaces(t *testing.T) {
+	var gotCommands []string
+
+	client := &mockSSMCmdClient{
+		sendCommandFn: func(_ context.Context, in *awsssm.SendCommandInput, _ ...func(*awsssm.Options)) (*awsssm.SendCommandOutput, error) {
+			gotCommands = append([]string(nil), in.Parameters["commands"]...)
+			return &awsssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-win-path")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *awsssm.GetCommandInvocationInput, _ ...func(*awsssm.Options)) (*awsssm.GetCommandInvocationOutput, error) {
+			return &awsssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusSuccess,
+				ResponseCode: 0,
+			}, nil
+		},
+	}
+
+	ec2Client := &mockEC2CmdClient{
+		fn: func(_ context.Context, _ *awsec2.DescribeInstancesInput, _ ...func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {
+			return &awsec2.DescribeInstancesOutput{
+				Reservations: []ec2types.Reservation{
+					{
+						Instances: []ec2types.Instance{
+							{
+								InstanceId: aws.String("i-wintest"),
+								Platform:   ec2types.PlatformValuesWindows,
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	a := &app.App{
+		Config:    &config.Config{Timeout: 30 * time.Second},
+		SSMClient: client,
+		EC2Client: ec2Client,
+	}
+
+	err := executeRunCmd(context.Background(), a, []string{"run", "i-wintest", "--", `C:\Program Files\My Tool\tool.exe`, "arg value"})
+	if err != nil {
+		t.Fatalf("expected Windows target to run, got %v", err)
+	}
+
+	wantCommands := []string{`& 'C:\Program Files\My Tool\tool.exe' 'arg value'`}
+	if len(gotCommands) != len(wantCommands) || gotCommands[0] != wantCommands[0] {
+		t.Fatalf("commands = %#v, want %#v", gotCommands, wantCommands)
 	}
 }
 

--- a/internal/ssm/quote.go
+++ b/internal/ssm/quote.go
@@ -1,0 +1,25 @@
+package ssm
+
+import "strings"
+
+// shellQuote wraps s in single quotes for safe inclusion inside a POSIX shell
+// command, escaping any embedded single quotes.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// ShellQuote is the exported form of shellQuote, provided for use by the
+// benchmarks package and command-layer argument joining.
+func ShellQuote(s string) string {
+	return shellQuote(s)
+}
+
+func powerShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// PowerShellQuote wraps s in single quotes for safe inclusion inside a
+// PowerShell command, doubling any embedded single quotes.
+func PowerShellQuote(s string) string {
+	return powerShellQuote(s)
+}

--- a/internal/ssm/quote_test.go
+++ b/internal/ssm/quote_test.go
@@ -1,0 +1,19 @@
+package ssm
+
+import "testing"
+
+func TestShellQuote_ExportedWrapper(t *testing.T) {
+	got := ShellQuote("it's /tmp/file.txt")
+	want := `'it'\''s /tmp/file.txt'`
+	if got != want {
+		t.Fatalf("ShellQuote() = %q, want %q", got, want)
+	}
+}
+
+func TestPowerShellQuote_ExportedWrapper(t *testing.T) {
+	got := PowerShellQuote("it's C:\\Temp\\file.txt")
+	want := `'it''s C:\Temp\file.txt'`
+	if got != want {
+		t.Fatalf("PowerShellQuote() = %q, want %q", got, want)
+	}
+}

--- a/internal/ssm/run.go
+++ b/internal/ssm/run.go
@@ -38,13 +38,37 @@ type Result struct {
 	ExitCode int
 }
 
+const (
+	runShellDocument      = "AWS-RunShellScript"
+	runPowerShellDocument = "AWS-RunPowerShellScript"
+)
+
 // RunCommand sends a command to an EC2 instance via Systems Manager and waits
 // for completion. It polls for the command invocation status until the command
 // finishes or the context is cancelled. Returns the command output and exit code.
 func RunCommand(ctx context.Context, client RunAPI, instanceID string, command []string, timeout time.Duration) (*Result, error) {
+	return runCommandWithDocument(ctx, client, instanceID, runShellDocument, command, timeout)
+}
+
+// RunPowerShellCommand sends a command to a Windows EC2 instance via Systems
+// Manager using the AWS-RunPowerShellScript document.
+func RunPowerShellCommand(ctx context.Context, client RunAPI, instanceID string, command []string, timeout time.Duration) (*Result, error) {
+	return runCommandWithDocument(ctx, client, instanceID, runPowerShellDocument, command, timeout)
+}
+
+// RunCommandForTarget chooses the appropriate SSM Run Command document for the
+// resolved target platform.
+func RunCommandForTarget(ctx context.Context, client RunAPI, target TargetInfo, command []string, timeout time.Duration) (*Result, error) {
+	if target.IsWindows() {
+		return RunPowerShellCommand(ctx, client, target.InstanceID, command, timeout)
+	}
+	return RunCommand(ctx, client, target.InstanceID, command, timeout)
+}
+
+func runCommandWithDocument(ctx context.Context, client RunAPI, instanceID, documentName string, command []string, timeout time.Duration) (*Result, error) {
 	resp, err := client.SendCommand(ctx, &ssm.SendCommandInput{
 		InstanceIds:  []string{instanceID},
-		DocumentName: aws.String("AWS-RunShellScript"),
+		DocumentName: aws.String(documentName),
 		Parameters: map[string][]string{
 			"commands": command,
 		},

--- a/internal/ssm/run_test.go
+++ b/internal/ssm/run_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 )
@@ -126,6 +127,79 @@ func TestRunCommand_SendCommandError(t *testing.T) {
 	_, err := RunCommand(context.Background(), client, "i-123", []string{"echo hi"}, 30*time.Second)
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRunPowerShellCommand_UsesPowerShellDocument(t *testing.T) {
+	var gotDocument string
+
+	client := &mockSSMRunClient{
+		sendCommandFn: func(_ context.Context, in *ssm.SendCommandInput, _ ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
+			gotDocument = aws.ToString(in.DocumentName)
+			return &ssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-ps")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *ssm.GetCommandInvocationInput, _ ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
+			return &ssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusSuccess,
+				ResponseCode: 0,
+			}, nil
+		},
+	}
+
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	if _, err := RunPowerShellCommand(context.Background(), client, "i-win", []string{"Get-Process"}, 30*time.Second); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotDocument != runPowerShellDocument {
+		t.Fatalf("DocumentName = %q, want %q", gotDocument, runPowerShellDocument)
+	}
+}
+
+func TestRunCommandForTarget_UsesPlatformDocument(t *testing.T) {
+	var gotDocuments []string
+
+	client := &mockSSMRunClient{
+		sendCommandFn: func(_ context.Context, in *ssm.SendCommandInput, _ ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
+			gotDocuments = append(gotDocuments, aws.ToString(in.DocumentName))
+			return &ssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-target")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *ssm.GetCommandInvocationInput, _ ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
+			return &ssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusSuccess,
+				ResponseCode: 0,
+			}, nil
+		},
+	}
+
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	targets := []TargetInfo{
+		{InstanceID: "i-linux"},
+		{InstanceID: "i-win", Platform: ec2types.PlatformValuesWindows},
+	}
+
+	for _, target := range targets {
+		if _, err := RunCommandForTarget(context.Background(), client, target, []string{"echo ok"}, 30*time.Second); err != nil {
+			t.Fatalf("unexpected error for %s: %v", target.InstanceID, err)
+		}
+	}
+
+	want := []string{runShellDocument, runPowerShellDocument}
+	if len(gotDocuments) != len(want) {
+		t.Fatalf("captured %d documents, want %d", len(gotDocuments), len(want))
+	}
+	for i := range want {
+		if gotDocuments[i] != want[i] {
+			t.Fatalf("DocumentName[%d] = %q, want %q", i, gotDocuments[i], want[i])
+		}
 	}
 }
 

--- a/internal/ssm/transfer.go
+++ b/internal/ssm/transfer.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	tempFile  = "/tmp/._ssmctl_transfer"
-	chunkSize = 3072
+	unixTempFile    = "/tmp/._ssmctl_transfer"
+	windowsTempFile = `C:\Windows\Temp\._ssmctl_transfer`
+	chunkSize       = 3072
 )
 
 // TransferResult contains the summary of a completed file transfer operation.
@@ -55,15 +56,22 @@ func ParseArg(s string) (instance, path string, isRemote bool) {
 // Safety note: base64-encoded chunks are passed to the remote shell with
 // heredoc. The 'EOF' delimiter is single-quoted, which prevents shell
 // interpretation of any characters in the chunk (i.e., +, /, =).
-func Upload(ctx context.Context, client RunAPI, instanceID, localPath, remotePath string, timeout time.Duration) (*TransferResult, error) {
+func Upload(ctx context.Context, client RunAPI, target TargetInfo, localPath, remotePath string, timeout time.Duration) (*TransferResult, error) {
 	data, err := os.ReadFile(localPath) // #nosec G304 -- localPath is a user-supplied CLI argument, path traversal is intentional
 	if err != nil {
 		return nil, fmt.Errorf("failed to read local file: %w", err)
 	}
 
 	encoded := base64.StdEncoding.EncodeToString(data)
+	tempFile := tempFileForTarget(target)
 
-	init, err := RunCommand(ctx, client, instanceID, []string{fmt.Sprintf("printf '' > %s", tempFile)}, timeout)
+	initCmd := fmt.Sprintf("printf '' > %s", tempFile)
+	if target.IsWindows() {
+		remotePath = normalizeWindowsPath(remotePath)
+		initCmd = fmt.Sprintf("[System.IO.File]::WriteAllBytes(%s, [byte[]]@())", powerShellQuote(tempFile))
+	}
+
+	init, err := RunCommandForTarget(ctx, client, target, []string{initCmd}, timeout)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialise transfer file: %w", err)
@@ -80,17 +88,23 @@ func Upload(ctx context.Context, client RunAPI, instanceID, localPath, remotePat
 		}
 		chunk := encoded[i:end]
 
+		command := fmt.Sprintf(
+			"cat << 'EOF' | base64 -d >> %s\n%s\nEOF",
+			tempFile,
+			chunk,
+		)
+		if target.IsWindows() {
+			command = fmt.Sprintf(
+				"$bytes = [System.Convert]::FromBase64String(%s); $stream = [System.IO.File]::Open(%s, [System.IO.FileMode]::Append, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None); try { $stream.Write($bytes, 0, $bytes.Length) } finally { $stream.Dispose() }",
+				powerShellQuote(chunk),
+				powerShellQuote(tempFile),
+			)
+		}
+
 		// Using heredoc with single-quoted EOF delimiter for safe base64
 		// chunk embedding to prevent interpretation of special characters
 		// such as: +, /, =.
-		result, err := RunCommand(ctx, client, instanceID,
-			[]string{fmt.Sprintf(
-				"cat << 'EOF' | base64 -d >> %s\n%s\nEOF",
-				tempFile,
-				chunk,
-			)},
-			timeout,
-		)
+		result, err := RunCommandForTarget(ctx, client, target, []string{command}, timeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to send chunk: %w", err)
 		}
@@ -100,11 +114,16 @@ func Upload(ctx context.Context, client RunAPI, instanceID, localPath, remotePat
 		chunks++
 	}
 
-	dir := path.Dir(remotePath)
-	result, err := RunCommand(ctx, client, instanceID,
-		[]string{fmt.Sprintf("mkdir -p %s && mv %s %s", dir, tempFile, remotePath)},
-		timeout,
-	)
+	finaliseCmd := fmt.Sprintf("mkdir -p %s && mv %s %s", path.Dir(remotePath), tempFile, remotePath)
+	if target.IsWindows() {
+		finaliseCmd = fmt.Sprintf(
+			"$destination = %s; $dir = [System.IO.Path]::GetDirectoryName($destination); if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }; Move-Item -Force -LiteralPath %s -Destination $destination",
+			powerShellQuote(remotePath),
+			powerShellQuote(tempFile),
+		)
+	}
+
+	result, err := RunCommandForTarget(ctx, client, target, []string{finaliseCmd}, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to move file to destination: %w", err)
 	}
@@ -115,7 +134,7 @@ func Upload(ctx context.Context, client RunAPI, instanceID, localPath, remotePat
 	return &TransferResult{
 		Direction:   "upload",
 		Source:      localPath,
-		Destination: instanceID + ":" + remotePath,
+		Destination: target.InstanceID + ":" + remotePath,
 		Bytes:       int64(len(data)),
 		Chunks:      chunks,
 	}, nil
@@ -123,11 +142,14 @@ func Upload(ctx context.Context, client RunAPI, instanceID, localPath, remotePat
 
 // Download copies a remote file to a local path via SSM.
 // Practical limit: ~36KB due to SSM stdout truncation.
-func Download(ctx context.Context, client RunAPI, instanceID, remotePath, localPath string, timeout time.Duration) (*TransferResult, error) {
-	result, err := RunCommand(ctx, client, instanceID,
-		[]string{fmt.Sprintf("cat %s | base64", remotePath)},
-		timeout,
-	)
+func Download(ctx context.Context, client RunAPI, target TargetInfo, remotePath, localPath string, timeout time.Duration) (*TransferResult, error) {
+	command := fmt.Sprintf("cat %s | base64", remotePath)
+	if target.IsWindows() {
+		remotePath = normalizeWindowsPath(remotePath)
+		command = fmt.Sprintf("[System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes(%s))", powerShellQuote(remotePath))
+	}
+
+	result, err := RunCommandForTarget(ctx, client, target, []string{command}, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read remote file: %w", err)
 	}
@@ -146,8 +168,19 @@ func Download(ctx context.Context, client RunAPI, instanceID, remotePath, localP
 
 	return &TransferResult{
 		Direction:   "download",
-		Source:      instanceID + ":" + remotePath,
+		Source:      target.InstanceID + ":" + remotePath,
 		Destination: localPath,
 		Bytes:       int64(len(data)),
 	}, nil
+}
+
+func tempFileForTarget(target TargetInfo) string {
+	if target.IsWindows() {
+		return windowsTempFile
+	}
+	return unixTempFile
+}
+
+func normalizeWindowsPath(p string) string {
+	return strings.ReplaceAll(p, "/", `\`)
 }

--- a/internal/ssm/transfer.go
+++ b/internal/ssm/transfer.go
@@ -11,6 +11,9 @@ import (
 )
 
 const (
+	// These scratch paths are shared per-instance, so concurrent transfers to
+	// the same target can race and clobber each other. Keep only one active
+	// in-band transfer per instance until we move to unique temp paths.
 	unixTempFile    = "/tmp/._ssmctl_transfer"
 	windowsTempFile = `C:\Windows\Temp\._ssmctl_transfer`
 	chunkSize       = 3072

--- a/internal/ssm/transfer_s3.go
+++ b/internal/ssm/transfer_s3.go
@@ -199,6 +199,10 @@ func DownloadViaS3(
 	keepStaging bool,
 	timeout time.Duration,
 ) (*TransferResult, error) {
+	// Derive the staging basename from the original user path before any
+	// Windows-only normalization. remoteBaseName handles backslash conversion
+	// itself, so keeping the raw path here avoids coupling key naming to the
+	// later command-string rewrite.
 	key, err := stagingKeyFunc(staging.Prefix, remoteBaseName(target, remotePath))
 	if err != nil {
 		return nil, err

--- a/internal/ssm/transfer_s3.go
+++ b/internal/ssm/transfer_s3.go
@@ -110,7 +110,7 @@ func UploadViaS3(
 	ctx context.Context,
 	ssmClient RunAPI,
 	s3Client S3API,
-	instanceID string,
+	target TargetInfo,
 	localPath, remotePath string,
 	staging S3Location,
 	keepStaging bool,
@@ -150,7 +150,16 @@ func UploadViaS3(
 		shellQuote(remotePath),
 	)
 
-	result, runErr := RunCommand(ctx, ssmClient, instanceID, []string{pullCmd}, timeout)
+	if target.IsWindows() {
+		remotePath = normalizeWindowsPath(remotePath)
+		pullCmd = fmt.Sprintf(
+			"$destination = %s; $dir = [System.IO.Path]::GetDirectoryName($destination); if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }; aws s3 cp %s $destination",
+			powerShellQuote(remotePath),
+			powerShellQuote(stagedURL),
+		)
+	}
+
+	result, runErr := RunCommandForTarget(ctx, ssmClient, target, []string{pullCmd}, timeout)
 	cleanupErr := maybeCleanupStagingObject(ctx, s3Client, staging.Bucket, key, keepStaging, runErr == nil && result != nil && result.ExitCode == 0)
 
 	if runErr != nil {
@@ -166,7 +175,7 @@ func UploadViaS3(
 	return &TransferResult{
 		Direction:   "upload",
 		Source:      localPath,
-		Destination: instanceID + ":" + remotePath,
+		Destination: target.InstanceID + ":" + remotePath,
 		Bytes:       stat.Size(),
 		Via:         "s3",
 		StagingURL:  stagedURL,
@@ -184,13 +193,13 @@ func DownloadViaS3(
 	ctx context.Context,
 	ssmClient RunAPI,
 	s3Client S3API,
-	instanceID string,
+	target TargetInfo,
 	remotePath, localPath string,
 	staging S3Location,
 	keepStaging bool,
 	timeout time.Duration,
 ) (*TransferResult, error) {
-	key, err := stagingKeyFunc(staging.Prefix, path.Base(remotePath))
+	key, err := stagingKeyFunc(staging.Prefix, remoteBaseName(target, remotePath))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +211,16 @@ func DownloadViaS3(
 		shellQuote(stagedURL),
 	)
 
-	pushed, runErr := RunCommand(ctx, ssmClient, instanceID, []string{pushCmd}, timeout)
+	if target.IsWindows() {
+		remotePath = normalizeWindowsPath(remotePath)
+		pushCmd = fmt.Sprintf(
+			"$source = %s; aws s3 cp $source %s",
+			powerShellQuote(remotePath),
+			powerShellQuote(stagedURL),
+		)
+	}
+
+	pushed, runErr := RunCommandForTarget(ctx, ssmClient, target, []string{pushCmd}, timeout)
 	if runErr != nil {
 		return nil, fmt.Errorf("failed to push remote file to S3: %w", runErr)
 	}
@@ -223,7 +241,7 @@ func DownloadViaS3(
 
 	return &TransferResult{
 		Direction:   "download",
-		Source:      instanceID + ":" + remotePath,
+		Source:      target.InstanceID + ":" + remotePath,
 		Destination: localPath,
 		Bytes:       bytes,
 		Via:         "s3",
@@ -255,6 +273,13 @@ func fetchStagedObject(ctx context.Context, s3Client S3API, bucket, key, localPa
 	return n, nil
 }
 
+func remoteBaseName(target TargetInfo, remotePath string) string {
+	if target.IsWindows() {
+		return path.Base(strings.ReplaceAll(remotePath, `\`, "/"))
+	}
+	return path.Base(remotePath)
+}
+
 // maybeCleanupStagingObject deletes the staging object unless keepStaging is
 // true. It is only invoked after the caller knows whether the prior step
 // succeeded so that failed transfers can choose to leave staging artefacts in
@@ -273,16 +298,4 @@ func maybeCleanupStagingObject(ctx context.Context, s3Client S3API, bucket, key 
 		return fmt.Errorf("failed to delete staging object s3://%s/%s: %w", bucket, key, err)
 	}
 	return nil
-}
-
-// shellQuote wraps s in single quotes for safe inclusion inside a POSIX shell
-// command, escaping any embedded single quotes.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
-
-// ShellQuote is the exported form of shellQuote, provided for use by the
-// benchmarks package.
-func ShellQuote(s string) string {
-	return shellQuote(s)
 }

--- a/internal/ssm/transfer_s3_test.go
+++ b/internal/ssm/transfer_s3_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
@@ -258,7 +259,7 @@ func TestUploadViaS3_Success(t *testing.T) {
 	result, err := UploadViaS3(
 		context.Background(),
 		mockSSM, mockS3,
-		"i-123",
+		TargetInfo{InstanceID: "i-123"},
 		localFile, "/var/data/payload.tar.gz",
 		S3Location{Bucket: "my-bucket", Prefix: "tmp"},
 		false,
@@ -324,7 +325,7 @@ func TestUploadViaS3_KeepStaging(t *testing.T) {
 	result, err := UploadViaS3(
 		context.Background(),
 		mockSSM, mockS3,
-		"i-keep",
+		TargetInfo{InstanceID: "i-keep"},
 		localFile, "/tmp/file.bin",
 		S3Location{Bucket: "b"},
 		true,
@@ -357,7 +358,7 @@ func TestUploadViaS3_PutObjectFails(t *testing.T) {
 	_, err := UploadViaS3(
 		context.Background(),
 		mockSSM, mockS3,
-		"i-123",
+		TargetInfo{InstanceID: "i-123"},
 		localFile, "/tmp/file.txt",
 		S3Location{Bucket: "b"},
 		false,
@@ -388,7 +389,7 @@ func TestUploadViaS3_RemoteCommandFails_LeavesStaging(t *testing.T) {
 	_, err := UploadViaS3(
 		context.Background(),
 		mockSSM, mockS3,
-		"i-fail",
+		TargetInfo{InstanceID: "i-fail"},
 		localFile, "/tmp/file.txt",
 		S3Location{Bucket: "b"},
 		false,
@@ -423,7 +424,7 @@ func TestDownloadViaS3_Success(t *testing.T) {
 	result, err := DownloadViaS3(
 		context.Background(),
 		mockSSM, mockS3,
-		"i-456",
+		TargetInfo{InstanceID: "i-456"},
 		"/var/log/app.log", localFile,
 		S3Location{Bucket: "my-bucket", Prefix: "tmp"},
 		false,
@@ -480,7 +481,7 @@ func TestDownloadViaS3_KeepStaging(t *testing.T) {
 	result, err := DownloadViaS3(
 		context.Background(),
 		mockSSM, mockS3,
-		"i-keep",
+		TargetInfo{InstanceID: "i-keep"},
 		"/remote/file.log", localFile,
 		S3Location{Bucket: "b"},
 		true,
@@ -510,7 +511,7 @@ func TestDownloadViaS3_RemotePushFails(t *testing.T) {
 	_, err := DownloadViaS3(
 		context.Background(),
 		mockSSM, mockS3,
-		"i-fail",
+		TargetInfo{InstanceID: "i-fail"},
 		"/missing.log", localFile,
 		S3Location{Bucket: "b"},
 		false,
@@ -542,7 +543,7 @@ func TestDownloadViaS3_GetObjectFails(t *testing.T) {
 	_, err := DownloadViaS3(
 		context.Background(),
 		mockSSM, mockS3,
-		"i-x",
+		TargetInfo{InstanceID: "i-x"},
 		"/remote/file.log", localFile,
 		S3Location{Bucket: "b"},
 		false,
@@ -553,5 +554,75 @@ func TestDownloadViaS3_GetObjectFails(t *testing.T) {
 	}
 	if mockS3.deleteCalls != 0 {
 		t.Errorf("expected to leave staging for diagnostics on Get failure, got %d delete calls", mockS3.deleteCalls)
+	}
+}
+
+func TestUploadViaS3_WindowsUsesPowerShellAndNormalizesPath(t *testing.T) {
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	withFixedStagingKey(t, "tmp/ssmctl-win-file.zip")
+
+	localFile := filepath.Join(t.TempDir(), "file.zip")
+	if err := os.WriteFile(localFile, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	mockS3 := newMockS3Client()
+	var ranCmds []string
+	mockSSM := ssmRunCapturer(&ranCmds, 0, "")
+
+	target := TargetInfo{InstanceID: "i-win", Platform: ec2types.PlatformValuesWindows}
+	if _, err := UploadViaS3(
+		context.Background(),
+		mockSSM, mockS3,
+		target,
+		localFile, `C:/Artifacts/build/file.zip`,
+		S3Location{Bucket: "my-bucket", Prefix: "tmp"},
+		false,
+		30*time.Second,
+	); err != nil {
+		t.Fatalf("UploadViaS3 error: %v", err)
+	}
+
+	if len(ranCmds) != 1 {
+		t.Fatalf("expected 1 SSM command, got %d", len(ranCmds))
+	}
+	if !strings.Contains(ranCmds[0], "New-Item -ItemType Directory -Force") || !strings.Contains(ranCmds[0], `C:\Artifacts\build\file.zip`) {
+		t.Fatalf("unexpected Windows S3 upload command: %q", ranCmds[0])
+	}
+}
+
+func TestDownloadViaS3_WindowsUsesPowerShellAndWindowsBasename(t *testing.T) {
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	withFixedStagingKey(t, "tmp/ssmctl-win-app.log")
+
+	mockS3 := newMockS3Client()
+	mockS3.objects["my-bucket/tmp/ssmctl-win-app.log"] = []byte("LOG")
+
+	var ranCmds []string
+	mockSSM := ssmRunCapturer(&ranCmds, 0, "")
+
+	localFile := filepath.Join(t.TempDir(), "out.log")
+	target := TargetInfo{InstanceID: "i-win", Platform: ec2types.PlatformValuesWindows}
+	if _, err := DownloadViaS3(
+		context.Background(),
+		mockSSM, mockS3,
+		target,
+		`C:\Logs\app.log`, localFile,
+		S3Location{Bucket: "my-bucket", Prefix: "tmp"},
+		false,
+		30*time.Second,
+	); err != nil {
+		t.Fatalf("DownloadViaS3 error: %v", err)
+	}
+
+	if got := mockS3.capturedGets[0]; got != "my-bucket/tmp/ssmctl-win-app.log" {
+		t.Fatalf("GetObject target = %q, want %q", got, "my-bucket/tmp/ssmctl-win-app.log")
+	}
+	if len(ranCmds) != 1 || !strings.Contains(ranCmds[0], `C:\Logs\app.log`) {
+		t.Fatalf("unexpected Windows S3 download command: %#v", ranCmds)
 	}
 }

--- a/internal/ssm/transfer_test.go
+++ b/internal/ssm/transfer_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 )
@@ -109,7 +110,7 @@ func TestUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := Upload(context.Background(), alwaysSucceedClient(), "i-123", localFile, "/tmp/upload.txt", 30*time.Second)
+	result, err := Upload(context.Background(), alwaysSucceedClient(), TargetInfo{InstanceID: "i-123"}, localFile, "/tmp/upload.txt", 30*time.Second)
 	if err != nil {
 		t.Fatalf("Upload() error = %v", err)
 	}
@@ -157,7 +158,7 @@ func TestDownload(t *testing.T) {
 
 	localFile := filepath.Join(t.TempDir(), "download.txt")
 
-	result, err := Download(context.Background(), client, "i-123", "/remote/file.txt", localFile, 30*time.Second)
+	result, err := Download(context.Background(), client, TargetInfo{InstanceID: "i-123"}, "/remote/file.txt", localFile, 30*time.Second)
 	if err != nil {
 		t.Fatalf("Download() error = %v", err)
 	}
@@ -206,7 +207,7 @@ func TestDownload_RemoteCommandFails(t *testing.T) {
 	}
 
 	localFile := filepath.Join(t.TempDir(), "should_not_exist.txt")
-	_, err := Download(context.Background(), client, "i-123", "/nonexistent/file.txt", localFile, 30*time.Second)
+	_, err := Download(context.Background(), client, TargetInfo{InstanceID: "i-123"}, "/nonexistent/file.txt", localFile, 30*time.Second)
 	if err == nil {
 		t.Fatal("expected error for failed remote command, got nil")
 	}
@@ -264,11 +265,102 @@ func TestUploadChunkWithSpecialBase64Characters(t *testing.T) {
 	}
 
 	// Upload should succeed with special base64 characters safely embedded in heredoc.
-	_, err := Upload(context.Background(), client, "i-123", localFile, "/tmp/special.bin", 30*time.Second)
+	_, err := Upload(context.Background(), client, TargetInfo{InstanceID: "i-123"}, localFile, "/tmp/special.bin", 30*time.Second)
 	if err != nil {
 		t.Fatalf("Upload() with special base64 chars error = %v", err)
 	}
 	if !heredocFound {
 		t.Error("expected at least one chunk command to use heredoc syntax, got none")
+	}
+}
+
+func TestUpload_WindowsUsesPowerShellCommands(t *testing.T) {
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	localFile := filepath.Join(t.TempDir(), "upload.txt")
+	if err := os.WriteFile(localFile, []byte("hello windows upload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var commands []string
+	var documents []string
+	client := &mockSSMRunClient{
+		sendCommandFn: func(_ context.Context, input *ssm.SendCommandInput, _ ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
+			documents = append(documents, aws.ToString(input.DocumentName))
+			commands = append(commands, input.Parameters["commands"]...)
+			return &ssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-win-upload")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *ssm.GetCommandInvocationInput, _ ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
+			return &ssm.GetCommandInvocationOutput{
+				Status:       types.CommandInvocationStatusSuccess,
+				ResponseCode: 0,
+			}, nil
+		},
+	}
+
+	target := TargetInfo{InstanceID: "i-win", Platform: ec2types.PlatformValuesWindows}
+	if _, err := Upload(context.Background(), client, target, localFile, `C:/Temp/ssmctl/upload.txt`, 30*time.Second); err != nil {
+		t.Fatalf("Upload() error = %v", err)
+	}
+
+	if len(commands) < 3 {
+		t.Fatalf("expected at least 3 commands, got %d", len(commands))
+	}
+	for _, doc := range documents {
+		if doc != runPowerShellDocument {
+			t.Fatalf("DocumentName = %q, want %q", doc, runPowerShellDocument)
+		}
+	}
+	if !strings.Contains(commands[0], "[System.IO.File]::WriteAllBytes") {
+		t.Fatalf("init command = %q, want WriteAllBytes", commands[0])
+	}
+	if !strings.Contains(commands[1], "[System.Convert]::FromBase64String") || !strings.Contains(commands[1], "[System.IO.File]::Open") {
+		t.Fatalf("chunk command = %q, want PowerShell append logic", commands[1])
+	}
+	if !strings.Contains(commands[len(commands)-1], "Move-Item -Force -LiteralPath") || !strings.Contains(commands[len(commands)-1], `C:\Temp\ssmctl\upload.txt`) {
+		t.Fatalf("final command = %q, want PowerShell move to normalized Windows path", commands[len(commands)-1])
+	}
+}
+
+func TestDownload_WindowsUsesPowerShellCommands(t *testing.T) {
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	content := "hello windows download"
+	encoded := base64.StdEncoding.EncodeToString([]byte(content))
+
+	var gotDocument string
+	var gotCommand string
+	client := &mockSSMRunClient{
+		sendCommandFn: func(_ context.Context, input *ssm.SendCommandInput, _ ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
+			gotDocument = aws.ToString(input.DocumentName)
+			gotCommand = input.Parameters["commands"][0]
+			return &ssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-win-download")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *ssm.GetCommandInvocationInput, _ ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
+			return &ssm.GetCommandInvocationOutput{
+				Status:                types.CommandInvocationStatusSuccess,
+				StandardOutputContent: aws.String(encoded),
+				ResponseCode:          0,
+			}, nil
+		},
+	}
+
+	localFile := filepath.Join(t.TempDir(), "download.txt")
+	target := TargetInfo{InstanceID: "i-win", Platform: ec2types.PlatformValuesWindows}
+	if _, err := Download(context.Background(), client, target, `C:/Logs/app.log`, localFile, 30*time.Second); err != nil {
+		t.Fatalf("Download() error = %v", err)
+	}
+
+	if gotDocument != runPowerShellDocument {
+		t.Fatalf("DocumentName = %q, want %q", gotDocument, runPowerShellDocument)
+	}
+	if !strings.Contains(gotCommand, "[System.IO.File]::ReadAllBytes") || !strings.Contains(gotCommand, `C:\Logs\app.log`) {
+		t.Fatalf("command = %q, want PowerShell ReadAllBytes against normalized Windows path", gotCommand)
 	}
 }


### PR DESCRIPTION
## Summary
- add Windows-aware command execution by switching `run` to `AWS-RunPowerShellScript` for Windows targets
- implement Windows in-band and S3-backed `cp` transfers with PowerShell command construction and path normalization
- extend unit, CLI, and tagged AWS e2e coverage and update the command docs/platform support table

## Testing
- go test ./internal/ssm -count=1
- go test ./internal/cmd -count=1
- go test ./... -count=1
- go test -tags e2e ./e2e -count=1

Fixes #76