### PR TITLE
ci: run on push to main so Codecov badge reflects merged coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Adds a `push: branches: [main]` trigger alongside the existing `pull_request` trigger
- Without this, CI (and the Codecov upload) only ever ran on PRs — never after a merge to main
- The Codecov badge points to `branch/main` coverage data which never existed, causing the persistent "unknown" badge

## No behaviour change for PRs

All existing PR checks are unchanged. The only addition is that the same job now also runs after each merge to main, giving Codecov the data it needs to serve the badge.

Made with [Cursor](https://cursor.com)