### PR TITLE
feat(release-please.yml): added SLSA generator step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -151,9 +151,9 @@ jobs:
 
   provenance:
     name: Generate SLSA Provenance
-    needs: [release-please, build-and-release]
+    needs: [build-and-release]
     permissions:
-      actions: read # "Needed for detection of Github Actions environment"
+      actions: read # "Needed for detection of GitHub Actions environment"
       id-token: write # "Needed for provenance signing and ID"
       contents: write # "Needed for release uploads"
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,8 @@ jobs:
   build-and-release:
     name: Build and Release
     needs: release-please
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     if: |
       github.repository == 'rhysmcneill/ssmctl' && (
         github.event_name == 'workflow_dispatch' ||
@@ -67,6 +69,20 @@ jobs:
             ssmctl-linux-arm64 \
             ssmctl-windows-amd64.exe \
             ssmctl-windows-arm64.exe > checksums.txt
+
+      - name: Generate hashes # added for slsa generator
+        shell: bash
+        id: hash
+        run: |
+          cd bin
+          sha256sum \
+            ssmctl-darwin-amd64 \
+            ssmctl-darwin-arm64 \
+            ssmctl-linux-amd64 \
+            ssmctl-linux-arm64 \
+            ssmctl-windows-amd64.exe \
+            ssmctl-windows-arm64.exe | base64 -w0 > hashes.txt
+          echo "hashes=$(cat hashes.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Verify checksum manifest
         run: |
@@ -132,3 +148,15 @@ jobs:
           git add Formula/ssmctl.rb
           git commit -m "chore: bump ssmctl to v${VERSION}"
           git push
+
+  provenance:
+    name: Generate SLSA Provenance
+    needs: [release-please, build-and-release]
+    permissions:
+      actions: read # "Needed for detection of Github Actions environment"
+      id-token: write # "Needed for provenance signing and ID"
+      contents: write # "Needed for release uploads"
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.build-and-release.outputs.hashes }}"
+      upload-assets: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -74,15 +74,7 @@ jobs:
         shell: bash
         id: hash
         run: |
-          cd bin
-          sha256sum \
-            ssmctl-darwin-amd64 \
-            ssmctl-darwin-arm64 \
-            ssmctl-linux-amd64 \
-            ssmctl-linux-arm64 \
-            ssmctl-windows-amd64.exe \
-            ssmctl-windows-arm64.exe | base64 -w0 > hashes.txt
-          echo "hashes=$(cat hashes.txt)" >> "$GITHUB_OUTPUT"
+          echo "hashes=$(base64 -w0 < bin/checksums.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Verify checksum manifest
         run: |

--- a/README.md
+++ b/README.md
@@ -85,35 +85,6 @@ ssmctl completion fish > ~/.config/fish/completions/ssmctl.fish
 
 ---
 
-## Verify Build Provenance
-
-All `ssmctl` releases are signed and come with SLSA provenance attestations. You can verify that a binary was built by our trusted CI/CD pipeline and hasn't been tampered with.
-
-### Install the verifier
-
-#### Option 1: Install via Go
-```bash
-$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.7.1
-```
-
-#### Option 2: Install via Homebrew
-
-```bash
-brew install slsa-verifier
-```
-
-### Verify the `.intoto.jsonl` file
-
-```bash
-slsa-verifier verify-artifact ssmctl-linux-amd64 \
-  --provenance-path ssmctl-linux-amd64.intoto.jsonl \
-  --source-uri github.com/rhysmcneill/ssmctl \
-  --source-tag v1.0.0
-```
-Replace v1.0.0 with the version you have downloaded.
-
----
-
 ## Real-world use cases
 
 ### Debug a production instance without a bastion
@@ -255,7 +226,8 @@ ssmctl list
 | | |
 |--|--|
 | [Command reference](docs/commands.md) | All commands, flags, and examples |
-| [Installation guide](docs/installation.md) | Setup, prerequisites, and verification |
+| [Installation guide](docs/installation.md) | Setup and prerequisites |
+| [Verification guide](docs/verification.md) | SLSA Attestation verification steps |
 | [IAM reference](docs/iam.md) | Exact permissions per command with copy-paste policies |
 | [Contributing](CONTRIBUTING.md) | How to build, test, and submit changes |
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,35 @@ ssmctl completion fish > ~/.config/fish/completions/ssmctl.fish
 
 ---
 
+## Verify Build Provenance
+
+All `ssmctl` releases are signed and come with SLSA provenance attestations. You can verify that a binary was built by our trusted CI/CD pipeline and hasn't been tampered with.
+
+### Install the verifier
+
+#### Option 1: Install via Go
+```bash
+$ go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.7.1
+```
+
+#### Option 2: Install via Homebrew
+
+```bash
+brew install slsa-verifier
+```
+
+### Verify the `.intoto.jsonl` file
+
+```bash
+slsa-verifier verify-artifact ssmctl-linux-amd64 \
+  --provenance-path ssmctl-linux-amd64.intoto.jsonl \
+  --source-uri github.com/rhysmcneill/ssmctl \
+  --source-tag v1.0.0
+```
+Replace v1.0.0 with the version you have downloaded.
+
+---
+
 ## Real-world use cases
 
 ### Debug a production instance without a bastion

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,30 @@
+# Verify Build Provenance
+
+All `ssmctl` releases are signed and come with SLSA provenance attestations. You can verify that a binary was built by our trusted CI/CD pipeline and hasn't been tampered with.
+
+## Install the verifier
+
+### Option 1: Install via Go
+
+```bash
+go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.7.1
+```
+
+### Option 2: Install via Homebrew
+
+```bash
+brew install slsa-verifier
+```
+
+## Verify the .intoto.jsonl file
+
+```bash
+slsa-verifier verify-artifact ssmctl-linux-amd64 \
+  --provenance-path ssmctl-linux-amd64.intoto.jsonl \
+  --source-uri github.com/rhysmcneill/ssmctl \
+  --source-tag v1.0.0
+```
+
+Replace v1.0.0.0 with the version you have downloaded.
+
+For additional and more in-depth explanation check out slsa-verifier's [documentation](https://github.com/slsa-framework/slsa-verifier/blob/main/README.md#verification-for-github-builders)

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -22,9 +22,9 @@ brew install slsa-verifier
 slsa-verifier verify-artifact ssmctl-linux-amd64 \
   --provenance-path ssmctl-linux-amd64.intoto.jsonl \
   --source-uri github.com/rhysmcneill/ssmctl \
-  --source-tag v1.0.0
+  --source-tag vX.Y.Z
 ```
 
-Replace v1.0.0.0 with the version you have downloaded.
+Replace vX.Y.Z with the version you have downloaded.
 
 For additional and more in-depth explanation check out slsa-verifier's [documentation](https://github.com/slsa-framework/slsa-verifier/blob/main/README.md#verification-for-github-builders)


### PR DESCRIPTION
## Summary
Some new steps were added to the `release-please.yml` file to add a slsa attestation generator for software verification. [slsa-verifier](https://github.com/slsa-framework/slsa-verifier/blob/main/README.md) was identified as the way to verify the generated attestation and a brief guide to using it was added to `README.md`. 

## Related issue
Closes #22 

## What changed
* `.github/workflows/release-please.yml`
* `README.md`

## Testing performed
make test
make lint

## Checklist
- ✅ I linked the related issue when applicable
- ✅  I reviewed testing standards in CONTRIBUTING.md
- ✅  I ran lint and formatting checks or explained why skipped
- ✅  I updated docs/comments if needed
- ✅  I followed commit conventions
- ✅ This PR is focused on one logical change
