### PR TITLE
fix(release-please): re-worked workflow permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,7 @@ jobs:
     needs: release-please
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
+      tag_name: ${{ steps.version.outputs.TAG }}
     if: |
       github.repository == 'rhysmcneill/ssmctl' && (
         github.event_name == 'workflow_dispatch' ||
@@ -106,7 +107,7 @@ jobs:
       - name: Derive version from release tag
         id: version
         run: |
-          TAG="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || needs.release-please.outputs.tag_name }}"
+          TAG= "${{ needs.build.ouputs.tag_name }}
           test -n "$TAG"
           echo "TAG=${TAG}" >> $GITHUB_OUTPUT
           echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,13 +9,14 @@ on:
         description: 'Release tag to build and publish (e.g. v2.0.0)'
         required: true
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   release-please:
     name: Release Please
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -28,8 +29,8 @@ jobs:
           config-file: tools/release/release-please-config.json
           manifest-file: tools/release/.release-please-manifest.json
 
-  build-and-release:
-    name: Build and Release
+  build:
+    name: Build
     needs: release-please
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -88,6 +89,33 @@ jobs:
             ssmctl-windows-arm64.exe; do
             grep -Eq "^[0-9a-f]{64}[[:space:]]+${file}$" checksums.txt
           done
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binaries
+          path: bin/
+          retention-days: 1
+
+  release:
+    name: Release and Update Homebrew
+    permissions:
+      contents: write
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Derive version from release tag
+        id: version
+        run: |
+          TAG="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || needs.release-please.outputs.tag_name }}"
+          test -n "$TAG"
+          echo "TAG=${TAG}" >> $GITHUB_OUTPUT
+          echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binaries
+          path: bin/
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2.6.1
@@ -143,12 +171,12 @@ jobs:
 
   provenance:
     name: Generate SLSA Provenance
-    needs: [build-and-release]
+    needs: [build, release]
     permissions:
       actions: read # "Needed for detection of GitHub Actions environment"
       id-token: write # "Needed for provenance signing and ID"
       contents: write # "Needed for release uploads"
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
-      base64-subjects: "${{ needs.build-and-release.outputs.hashes }}"
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Derive version from release tag
         id: version
         run: |
-          TAG= "${{ needs.build.ouputs.tag_name }}
+          TAG="${{ needs.build.outputs.tag_name }}"
           test -n "$TAG"
           echo "TAG=${TAG}" >> $GITHUB_OUTPUT
           echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -182,3 +182,4 @@ jobs:
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true
+      upload-tag-name: "${{ needs.build.outputs.tag_name }}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -101,6 +101,7 @@ jobs:
     name: Release and Update Homebrew
     permissions:
       contents: write
+      actions: read
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
`release-please.yml` workflow permissions were audited and reworked. 

## Related issue
Work for #120 

## What changed
- Top level workflow permission was set to `read-all`.
- `build-and-release` was split into `build` and `release` since only the release part of the job needed write permissions.
- `provenance` dependency was changed from `build-and-release` to `build` and `release`.

## Checklist
- ✅  I linked the related issue when applicable
- ✅  I reviewed testing standards in CONTRIBUTING.md
- ✅  I ran lint and formatting checks or explained why skipped
- ✅  I updated docs/comments if needed
- ✅  I followed commit conventions
- ✅  This PR is focused on one logical change
