### PR TITLE
ci(clusterfuzzlite): added clusterfuzzlite files and workflow yaml

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,5 +1,4 @@
 FROM gcr.io/oss-fuzz-base/base-builder-go:v1
-RUN apt-get update && apt-get install -y make autoconf automake libtool
 COPY . $SRC/ssmctl
 WORKDIR $SRC/ssmctl
 COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go:v1
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+COPY . $SRC/ssmctl
+WORKDIR $SRC/ssmctl
+COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -14,7 +14,6 @@
 #
 cd $SRC/ssmctl
 
-go mod download
 go mod tidy
 
 count=0

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -14,7 +14,7 @@
 #
 cd $SRC/ssmctl
 
-go mod tidy
+go mod download
 
 count=0
 

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -17,16 +17,26 @@ cd $SRC/ssmctl
 go mod download
 go mod tidy
 
-find ./internal/ssm -name "*_fuzz_test.go" -type f | xargs grep -E '^func Fuzz[A-Za-z0-9_]+\(' | while read -r line; do
+count=0
+
+# Use process substitution to avoid the subshell variable loss
+while read -r line; do
     # Extract just the function name (e.g., FuzzSanitizeBasename)
     func_name=$(echo "$line" | sed -E 's/.*func (Fuzz[A-Za-z0-9_]+)\(.*/\1/')
 
     # Convert the function name to lowercase for the binary output name
-    # (e.g., FuzzSanitizeBasename -> fuzz_sanitizebasename)
     binary_name=$(echo "$func_name" | tr '[:upper:]' '[:lower:]')
 
     echo "Building dynamic Go fuzzer: $func_name -> $binary_name"
 
     # Run the compilation command using the dynamic variables
     compile_native_go_fuzzer ./internal/ssm "$func_name" "$binary_name"
-done
+
+    count=$((count + 1))
+done < <(find ./internal/ssm -name "*_fuzz_test.go" -type f | xargs grep -E '^func Fuzz[A-Za-z0-9_]+\(')
+
+# Fixed spacing issues here
+if [ "$count" -eq 0 ]; then
+  echo "Error: no Fuzz functions found" >&2
+  exit 1
+fi

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -eu
+
+# build project
+# e.g.
+# ./autogen.sh
+# ./configure
+# make -j$(nproc) all
+
+# build fuzzers
+# e.g.
+# $CXX $CXXFLAGS -std=c++11 -Iinclude \
+#     /path/to/name_of_fuzzer.cc -o $OUT/name_of_fuzzer \
+#     $LIB_FUZZING_ENGINE /path/to/library.a
+#
+cd $SRC/ssmctl
+
+go mod download
+go mod tidy
+
+find ./internal/ssm -name "*_fuzz_test.go" -type f | xargs grep -E '^func Fuzz[A-Za-z0-9_]+\(' | while read -r line; do
+    # Extract just the function name (e.g., FuzzSanitizeBasename)
+    func_name=$(echo "$line" | sed -E 's/.*func (Fuzz[A-Za-z0-9_]+)\(.*/\1/')
+
+    # Convert the function name to lowercase for the binary output name
+    # (e.g., FuzzSanitizeBasename -> fuzz_sanitizebasename)
+    binary_name=$(echo "$func_name" | tr '[:upper:]' '[:lower:]')
+
+    echo "Building dynamic Go fuzzer: $func_name -> $binary_name"
+
+    # Run the compilation command using the dynamic variables
+    compile_native_go_fuzzer ./internal/ssm "$func_name" "$binary_name"
+done

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,17 +1,5 @@
 #!/bin/bash -eu
 
-# build project
-# e.g.
-# ./autogen.sh
-# ./configure
-# make -j$(nproc) all
-
-# build fuzzers
-# e.g.
-# $CXX $CXXFLAGS -std=c++11 -Iinclude \
-#     /path/to/name_of_fuzzer.cc -o $OUT/name_of_fuzzer \
-#     $LIB_FUZZING_ENGINE /path/to/library.a
-#
 cd $SRC/ssmctl
 
 go mod download

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -22,7 +22,6 @@ while read -r line; do
     count=$((count + 1))
 done < <(find ./internal/ssm -name "*_fuzz_test.go" -type f | xargs grep -E '^func Fuzz[A-Za-z0-9_]+\(')
 
-# Fixed spacing issues here
 if [ "$count" -eq 0 ]; then
   echo "Error: no Fuzz functions found" >&2
   exit 1

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: go

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -44,6 +44,6 @@ jobs:
         output-sarif: true
         # Optional but recommended: For storing certain artifacts from fuzzing.
         # See later section on "Git repo for storage".
-        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
-        # storage-repo-branch: main   # Optional. Defaults to "main"
-        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+        storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/MozamilS/ssmctl-cflite-corpus.git
+        storage-repo-branch: main   # Optional. Defaults to "main"
+        storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,0 +1,37 @@
+name: ClusterFuzzLite batch fuzzing
+on:
+  schedule:
+    - cron: "0 12 * * *"
+permissions: read-all
+jobs:
+  BatchFuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+        - address
+        # Override this with the sanitizers you want.
+        - undefined
+        - memory
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: go
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 3600
+        mode: 'batch'
+        sanitizer: ${{ matrix.sanitizer }}
+        output-sarif: true
+        # Optional but recommended: For storing certain artifacts from fuzzing.
+        # See later section on "Git repo for storage".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -34,6 +34,7 @@ jobs:
         sanitizer: ${{ matrix.sanitizer }}
     - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
+      if: steps.build.outcome == 'success'
       uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -2,23 +2,30 @@ name: ClusterFuzzLite batch fuzzing
 on:
   push:
     branches: [ "main"]
-  schedule:
-    - cron: "0 12 * * *"
+    paths:
+      - 'internal/ssm/**'
 
-permissions: read-all
+permissions: {}
 
 jobs:
   BatchFuzzing:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
         sanitizer:
         - address
         # Override this with the sanitizers you want.
-        - undefined
-        - memory
+        #- undefined
+        #- memory
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -42,8 +42,9 @@ jobs:
         mode: 'batch'
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
-        # Optional but recommended: For storing certain artifacts from fuzzing.
+        # Optional but recommended: used to download the corpus produced by
+        # batch fuzzing.
         # See later section on "Git repo for storage".
-        storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/MozamilS/ssmctl-cflite-corpus.git
-        storage-repo-branch: main   # Optional. Defaults to "main"
-        storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,8 +1,12 @@
 name: ClusterFuzzLite batch fuzzing
 on:
+  push:
+    branches: [ "main"]
   schedule:
     - cron: "0 12 * * *"
+
 permissions: read-all
+
 jobs:
   BatchFuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
       with:
         language: go
         sanitizer: ${{ matrix.sanitizer }}
     - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         fuzz-seconds: 3600

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: write
+      actions: write  # required for ClusterFuzzLite to upload corpus/artifact files
       security-events: write
     strategy:
       fail-fast: false

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -23,7 +23,7 @@ jobs:
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@v1
       with:
-        language: c++ # Change this to the language you are fuzzing.
+        language: go # Change this to the language you are fuzzing.
         github-token: ${{ secrets.GITHUB_TOKEN }}
         sanitizer: ${{ matrix.sanitizer }}
         # Optional but recommended: used to only run fuzzers that are affected

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -16,8 +16,8 @@ jobs:
         sanitizer:
         - address
         # Override this with the sanitizers you want.
-        # - undefined
-        # - memory
+        - undefined
+        - memory
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,8 +1,8 @@
 name: ClusterFuzzLite PR fuzzing
 on:
   pull_request:
-    branches:
-      - [ main ]
+    branches: [ "main" ]
+
 permissions: read-all
 jobs:
   PR:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -47,7 +47,7 @@ jobs:
       uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        fuzz-seconds: 600
+        fuzz-seconds: 30
         mode: 'code-change'
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,34 +1,49 @@
-name: ClusterFuzzLite PR Fuzzing
+name: ClusterFuzzLite PR fuzzing
 on:
   pull_request:
-    branches: [ main ]
-
-permissions: {}
-
+    branches:
+      - [ main ]
+permissions: read-all
 jobs:
   PR:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
       cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+        - address
+        # Override this with the sanitizers you want.
+        # - undefined
+        # - memory
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-    - name: Build Fuzzers
-      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
       with:
-        language: go
-        sanitizer: 'address'
-
-    - name: Run Fuzzers
-      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
+        language: c++ # Change this to the language you are fuzzing.
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        sanitizer: ${{ matrix.sanitizer }}
+        # Optional but recommended: used to only run fuzzers that are affected
+        # by the PR.
+        # See later section on "Git repo for storage".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        fuzz-seconds: 600 # Total max execution time (10 minutes) across your targets
+        fuzz-seconds: 600
         mode: 'code-change'
-        sanitizer: 'address'
-        language: go
+        sanitizer: ${{ matrix.sanitizer }}
+        output-sarif: true
+        # Optional but recommended: used to download the corpus produced by
+        # batch fuzzing.
+        # See later section on "Git repo for storage".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -43,6 +43,7 @@ jobs:
         # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
     - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
+      if: steps.build.outcome == 'success'
       uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,11 +2,17 @@ name: ClusterFuzzLite PR fuzzing
 on:
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'internal/ssm/**'
 
-permissions: read-all
+permissions: {}
 jobs:
   PR:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
       cancel-in-progress: true
@@ -16,9 +22,12 @@ jobs:
         sanitizer:
         - address
         # Override this with the sanitizers you want.
-        - undefined
-        - memory
+        #- undefined
+        #- memory
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,29 @@
+name: ClusterFuzzLite PR Fuzzing
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions: {}
+
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+
+    - name: Run Fuzzers
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 600 # Total max execution time (10 minutes) across your targets
+        mode: 'code-change'
+        sanitizer: 'address'
+        language: go

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -18,6 +18,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+    - name: Build Fuzzers
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
+      with:
+        language: go
+        sanitizer: 'address'
 
     - name: Run Fuzzers
       uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -54,6 +54,6 @@ jobs:
         # Optional but recommended: used to download the corpus produced by
         # batch fuzzing.
         # See later section on "Git repo for storage".
-        storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/MozamilS/ssmctl-cflite-corpus.git
-        storage-repo-branch: main   # Optional. Defaults to "main"
-        storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -54,6 +54,6 @@ jobs:
         # Optional but recommended: used to download the corpus produced by
         # batch fuzzing.
         # See later section on "Git repo for storage".
-        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
-        # storage-repo-branch: main   # Optional. Defaults to "main"
-        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+        storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/MozamilS/ssmctl-cflite-corpus.git
+        storage-repo-branch: main   # Optional. Defaults to "main"
+        storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
       with:
         language: go # Change this to the language you are fuzzing.
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
         # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
     - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1.15.3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         fuzz-seconds: 600


### PR DESCRIPTION
## Summary
This commit looks to add `clusterfuzzlite` to the codebase workflow. Its purpose is to run all fuzz functions in `./internal/ssm`. Batch and PR based workflows were added. They should only run when there's a change in `./internal/ssm/**` since there are no fuzzers beyond that directory.

For further reading, checkout [ClusterFuzzLite's documentation](https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/github-actions/#mode-configurations)

Firstly, all fuzz functions are found in the `./internal/ssm` directory and they are dynamically tested for. However, any additional fuzzers outside of this directory will not be found yet. 

## Related issue
Work for #120 

## What changed
- `.clusterfuzzlite` directory was added in project's root consisting of `Dockerfile`, `build.sh` and `project.yaml`
- `cflite_pr.yml` was added in `.github/workflows`. 
- `cflite_batch.yml` was added in `.github/workflows`.

## Testing performed

make test
make lint

## Checklist
- ✅ I linked the related issue when applicable
- ✅  I reviewed testing standards in CONTRIBUTING.md
- ✅  I ran lint and formatting checks or explained why skipped
- ✅  I updated docs/comments if needed
- ✅  I followed commit conventions
- ✅  This PR is focused on one logical change
