### PR TITLE
fix: match list filter against instance IDs

### DIFF
--- a/internal/ssm/list.go
+++ b/internal/ssm/list.go
@@ -45,6 +45,7 @@ func ListInstances(ctx context.Context, ssmClient ListAPI, ec2Client EC2Describe
 
 func filterInstances(items []ssmtypes.InstanceInformation, names map[string]string, filter, platform string) []InstanceInfo {
 	var result []InstanceInfo
+	filterLower := strings.ToLower(filter)
 	for _, item := range items {
 		id := aws.ToString(item.InstanceId)
 
@@ -56,7 +57,9 @@ func filterInstances(items []ssmtypes.InstanceInformation, names map[string]stri
 		platformStr := string(item.PlatformType)
 		status := string(item.PingStatus)
 
-		if filter != "" && !strings.Contains(strings.ToLower(name), strings.ToLower(filter)) {
+		if filterLower != "" &&
+			!strings.Contains(strings.ToLower(name), filterLower) &&
+			!strings.Contains(strings.ToLower(id), filterLower) {
 			continue
 		}
 		if platform != "" && !strings.EqualFold(platformStr, platform) {

--- a/internal/ssm/list_instances_filtering_fuzz_test.go
+++ b/internal/ssm/list_instances_filtering_fuzz_test.go
@@ -25,11 +25,19 @@ func FuzzListInstancesFiltering(f *testing.F) {
 
 		result := filterInstances(items, names, nameFilter, platformFilter)
 
-		// Invariant: if name filter is set, all results contain the filter substring
+		// Invariant: if a filter is set, all results contain the filter substring
+		// in either the Name tag or instance ID.
 		if nameFilter != "" {
 			for _, info := range result {
-				if !strings.Contains(strings.ToLower(info.Name), strings.ToLower(nameFilter)) {
-					t.Errorf("ListInstances: name %q does not contain filter %q", info.Name, nameFilter)
+				filter := strings.ToLower(nameFilter)
+				if !strings.Contains(strings.ToLower(info.Name), filter) &&
+					!strings.Contains(strings.ToLower(info.InstanceID), filter) {
+					t.Errorf(
+						"ListInstances: name %q and instance ID %q do not contain filter %q",
+						info.Name,
+						info.InstanceID,
+						nameFilter,
+					)
 				}
 			}
 		}

--- a/internal/ssm/list_test.go
+++ b/internal/ssm/list_test.go
@@ -101,6 +101,16 @@ func TestListInstances(t *testing.T) {
 			wantIDs: []string{"i-aaa"},
 		},
 		{
+			name: "filter narrows by instance ID substring case-insensitively",
+			ssm: &mockListAPI{pages: [][]ssmtypes.InstanceInformation{{
+				linuxInstance("i-abc123", "3.2.0"),
+				linuxInstance("i-def456", "3.2.0"),
+			}}},
+			ec2:     ec2WithNames(map[string]string{"i-abc123": "api-server", "i-def456": "worker"}),
+			filter:  "ABC",
+			wantIDs: []string{"i-abc123"},
+		},
+		{
 			name: "platform filter narrows by platform case-insensitively",
 			ssm: &mockListAPI{pages: [][]ssmtypes.InstanceInformation{{
 				linuxInstance("i-linux", "3.2.0"),


### PR DESCRIPTION
## Summary
- match `ssmctl list --filter` against both EC2 Name tags and instance IDs
- keep matching case-insensitive
- add a regression test for instance ID filtering and update the fuzz invariant

Fixes #165.

## Validation
- /tmp/go1.26.5-arm64/bin/gofmt -w internal/ssm/list.go internal/ssm/list_test.go internal/ssm/list_instances_filtering_fuzz_test.go
- /tmp/go1.26.5-arm64/bin/go test ./internal/ssm
- /tmp/go1.26.5-arm64/bin/go test ./...
- git diff --check