### PR TITLE
feat: add cp transfer progress reporting

### DIFF
--- a/internal/cmd/cp.go
+++ b/internal/cmd/cp.go
@@ -31,6 +31,8 @@ Download: ssmctl cp my-server:/var/log/app.log ./app.log
 
 Note: in-band SSM transfers are limited to ~2MB uploads and ~36KB downloads.
 Use --via s3://bucket/prefix to stage the file in S3 and lift those limits.
+Text output shows transfer progress on interactive terminals; JSON and piped
+output stay quiet.
 
 Linux/macOS targets use POSIX shell utilities under the hood. Windows targets
 use PowerShell for in-band transfers and require the AWS CLI on the instance
@@ -55,8 +57,9 @@ for the S3-backed path.`,
 			}
 
 			var (
-				result *ssmlib.TransferResult
-				err    error
+				result       *ssmlib.TransferResult
+				err          error
+				transferOpts = ssmlib.TransferOptions{}
 			)
 			switch {
 			case srcRemote && !dstRemote:
@@ -64,10 +67,11 @@ for the S3-backed path.`,
 				if resolveErr != nil {
 					return fmt.Errorf("resolve source instance: %w", resolveErr)
 				}
+				transferOpts.Progress = progressReporter(cmd, a.Config.Output, "Downloading")
 				if useS3 {
-					result, err = ssmlib.DownloadViaS3(cmd.Context(), a.SSMClient, a.S3Client, target, srcPath, dstPath, staging, opts.keepStaging, a.Config.Timeout)
+					result, err = ssmlib.DownloadViaS3WithOptions(cmd.Context(), a.SSMClient, a.S3Client, target, srcPath, dstPath, staging, opts.keepStaging, a.Config.Timeout, transferOpts)
 				} else {
-					result, err = ssmlib.Download(cmd.Context(), a.SSMClient, target, srcPath, dstPath, a.Config.Timeout)
+					result, err = ssmlib.DownloadWithOptions(cmd.Context(), a.SSMClient, target, srcPath, dstPath, a.Config.Timeout, transferOpts)
 				}
 
 			case !srcRemote && dstRemote:
@@ -75,10 +79,11 @@ for the S3-backed path.`,
 				if resolveErr != nil {
 					return fmt.Errorf("resolve destination instance: %w", resolveErr)
 				}
+				transferOpts.Progress = progressReporter(cmd, a.Config.Output, "Uploading")
 				if useS3 {
-					result, err = ssmlib.UploadViaS3(cmd.Context(), a.SSMClient, a.S3Client, target, srcPath, dstPath, staging, opts.keepStaging, a.Config.Timeout)
+					result, err = ssmlib.UploadViaS3WithOptions(cmd.Context(), a.SSMClient, a.S3Client, target, srcPath, dstPath, staging, opts.keepStaging, a.Config.Timeout, transferOpts)
 				} else {
-					result, err = ssmlib.Upload(cmd.Context(), a.SSMClient, target, srcPath, dstPath, a.Config.Timeout)
+					result, err = ssmlib.UploadWithOptions(cmd.Context(), a.SSMClient, target, srcPath, dstPath, a.Config.Timeout, transferOpts)
 				}
 
 			default:

--- a/internal/cmd/cp_progress.go
+++ b/internal/cmd/cp_progress.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	ssmlib "github.com/rhysmcneill/ssmctl/internal/ssm"
+)
+
+func progressReporter(cmd *cobra.Command, outputFormat, action string) ssmlib.ProgressFunc {
+	if outputFormat == "json" || !isTerminal(cmd.OutOrStdout()) {
+		return nil
+	}
+
+	return newProgressWriter(cmd.ErrOrStderr(), action)
+}
+
+func newProgressWriter(w io.Writer, action string) ssmlib.ProgressFunc {
+	var lastDone, lastTotal int64 = -1, -2
+	var finished bool
+
+	return func(done, total int64) {
+		if finished || done == lastDone && total == lastTotal {
+			return
+		}
+		lastDone, lastTotal = done, total
+
+		if total >= 0 {
+			percent := int64(100)
+			if total > 0 {
+				percent = done * 100 / total
+			}
+			if percent > 100 {
+				percent = 100
+			}
+			_, _ = fmt.Fprintf(w, "\r%s ... %s / %s (%d%%)", action, formatBytes(done), formatBytes(total), percent)
+			if done >= total {
+				_, _ = fmt.Fprintln(w)
+				finished = true
+			}
+			return
+		}
+
+		_, _ = fmt.Fprintf(w, "\r%s ... %s", action, formatBytes(done))
+	}
+}
+
+func isTerminal(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	stat, err := file.Stat()
+	return err == nil && stat.Mode()&os.ModeCharDevice != 0
+}
+
+func formatBytes(n int64) string {
+	if n < 1024 {
+		return fmt.Sprintf("%d B", n)
+	}
+
+	value := float64(n)
+	for _, unit := range []string{"KB", "MB", "GB", "TB"} {
+		value /= 1024
+		if value < 1024 {
+			return fmt.Sprintf("%.1f %s", value, unit)
+		}
+	}
+	return fmt.Sprintf("%.1f PB", value/1024)
+}

--- a/internal/cmd/cp_progress.go
+++ b/internal/cmd/cp_progress.go
@@ -11,7 +11,7 @@ import (
 )
 
 func progressReporter(cmd *cobra.Command, outputFormat, action string) ssmlib.ProgressFunc {
-	if outputFormat == "json" || !isTerminal(cmd.OutOrStdout()) {
+	if outputFormat == "json" || !isCharDevice(cmd.OutOrStdout()) {
 		return nil
 	}
 
@@ -23,14 +23,14 @@ func newProgressWriter(w io.Writer, action string) ssmlib.ProgressFunc {
 	var finished bool
 
 	return func(done, total int64) {
-		if finished || done == lastDone && total == lastTotal {
+		if finished || (done == lastDone && total == lastTotal) {
 			return
 		}
 		lastDone, lastTotal = done, total
 
 		if total >= 0 {
-			percent := int64(100)
-			if total > 0 {
+			percent := int64(0)
+			if done > 0 && total > 0 {
 				percent = done * 100 / total
 			}
 			if percent > 100 {
@@ -48,7 +48,10 @@ func newProgressWriter(w io.Writer, action string) ssmlib.ProgressFunc {
 	}
 }
 
-func isTerminal(w io.Writer) bool {
+// isCharDevice reports whether w is a character device. We use this as a TTY
+// heuristic: in practice cmd.OutOrStdout() is os.Stdout, a character device,
+// when running interactively.
+func isCharDevice(w io.Writer) bool {
 	file, ok := w.(*os.File)
 	if !ok {
 		return false

--- a/internal/cmd/cp_progress_test.go
+++ b/internal/cmd/cp_progress_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 
@@ -14,13 +15,36 @@ func TestProgressWriterFormatsByteCounts(t *testing.T) {
 
 	progress(0, 2048)
 	progress(1024, 2048)
+	progress(4096, 2048)
+	progress(2048, 2048)
 	progress(2048, 2048)
 
 	out := buf.String()
 	for _, want := range []string{
 		"Uploading ... 0 B / 2.0 KB (0%)",
 		"Uploading ... 1.0 KB / 2.0 KB (50%)",
-		"Uploading ... 2.0 KB / 2.0 KB (100%)\n",
+		"Uploading ... 4.0 KB / 2.0 KB (100%)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("progress output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "2.0 KB / 2.0 KB") {
+		t.Fatalf("progress output changed after completion:\n%s", out)
+	}
+}
+
+func TestProgressWriterFormatsUnknownAndLargeByteCounts(t *testing.T) {
+	var buf bytes.Buffer
+	progress := newProgressWriter(&buf, "Downloading")
+
+	progress(1536, -1)
+	progress(1<<50, 1<<50)
+
+	out := buf.String()
+	for _, want := range []string{
+		"Downloading ... 1.5 KB",
+		"Downloading ... 1.0 PB / 1.0 PB (100%)\n",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("progress output missing %q:\n%s", want, out)
@@ -37,5 +61,54 @@ func TestProgressReporterSuppressesJSONAndNonTTYOutput(t *testing.T) {
 	}
 	if got := progressReporter(cmd, "text", "Uploading"); got != nil {
 		t.Fatal("progressReporter returned a reporter for non-TTY stdout")
+	}
+}
+
+func TestProgressReporterWritesToStderrForTTYTextOutput(t *testing.T) {
+	tty, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
+	if err != nil {
+		t.Skipf("open /dev/null: %v", err)
+	}
+	defer func() { _ = tty.Close() }()
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(tty)
+	cmd.SetErr(&stderr)
+
+	progress := progressReporter(cmd, "text", "Uploading")
+	if progress == nil {
+		t.Fatal("progressReporter returned nil for TTY text output")
+	}
+	progress(1, 1)
+
+	if !strings.Contains(stderr.String(), "Uploading ... 1 B / 1 B (100%)") {
+		t.Fatalf("stderr progress output = %q", stderr.String())
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	if isTerminal(&bytes.Buffer{}) {
+		t.Fatal("bytes.Buffer reported as terminal")
+	}
+
+	tty, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
+	if err != nil {
+		t.Skipf("open /dev/null: %v", err)
+	}
+	defer func() { _ = tty.Close() }()
+	if !isTerminal(tty) {
+		t.Fatal("/dev/null did not report as a character device")
+	}
+
+	closed, err := os.CreateTemp(t.TempDir(), "closed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := closed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if isTerminal(closed) {
+		t.Fatal("closed file reported as terminal")
 	}
 }

--- a/internal/cmd/cp_progress_test.go
+++ b/internal/cmd/cp_progress_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestProgressWriterFormatsByteCounts(t *testing.T) {
+	var buf bytes.Buffer
+	progress := newProgressWriter(&buf, "Uploading")
+
+	progress(0, 2048)
+	progress(1024, 2048)
+	progress(2048, 2048)
+
+	out := buf.String()
+	for _, want := range []string{
+		"Uploading ... 0 B / 2.0 KB (0%)",
+		"Uploading ... 1.0 KB / 2.0 KB (50%)",
+		"Uploading ... 2.0 KB / 2.0 KB (100%)\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("progress output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestProgressReporterSuppressesJSONAndNonTTYOutput(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+
+	if got := progressReporter(cmd, "json", "Uploading"); got != nil {
+		t.Fatal("progressReporter returned a reporter for JSON output")
+	}
+	if got := progressReporter(cmd, "text", "Uploading"); got != nil {
+		t.Fatal("progressReporter returned a reporter for non-TTY stdout")
+	}
+}

--- a/internal/cmd/cp_progress_test.go
+++ b/internal/cmd/cp_progress_test.go
@@ -34,6 +34,17 @@ func TestProgressWriterFormatsByteCounts(t *testing.T) {
 	}
 }
 
+func TestProgressWriterFormatsZeroByteTransfer(t *testing.T) {
+	var buf bytes.Buffer
+	progress := newProgressWriter(&buf, "Uploading")
+
+	progress(0, 0)
+
+	if got, want := buf.String(), "\rUploading ... 0 B / 0 B (0%)\n"; got != want {
+		t.Fatalf("progress output = %q, want %q", got, want)
+	}
+}
+
 func TestProgressWriterFormatsUnknownAndLargeByteCounts(t *testing.T) {
 	var buf bytes.Buffer
 	progress := newProgressWriter(&buf, "Downloading")
@@ -87,9 +98,9 @@ func TestProgressReporterWritesToStderrForTTYTextOutput(t *testing.T) {
 	}
 }
 
-func TestIsTerminal(t *testing.T) {
-	if isTerminal(&bytes.Buffer{}) {
-		t.Fatal("bytes.Buffer reported as terminal")
+func TestIsCharDevice(t *testing.T) {
+	if isCharDevice(&bytes.Buffer{}) {
+		t.Fatal("bytes.Buffer reported as character device")
 	}
 
 	tty, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
@@ -97,7 +108,7 @@ func TestIsTerminal(t *testing.T) {
 		t.Skipf("open /dev/null: %v", err)
 	}
 	defer func() { _ = tty.Close() }()
-	if !isTerminal(tty) {
+	if !isCharDevice(tty) {
 		t.Fatal("/dev/null did not report as a character device")
 	}
 
@@ -108,7 +119,7 @@ func TestIsTerminal(t *testing.T) {
 	if err := closed.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if isTerminal(closed) {
-		t.Fatal("closed file reported as terminal")
+	if isCharDevice(closed) {
+		t.Fatal("closed file reported as character device")
 	}
 }

--- a/internal/ssm/progress.go
+++ b/internal/ssm/progress.go
@@ -1,0 +1,34 @@
+package ssm
+
+import "io"
+
+// ProgressFunc receives the completed and total byte counts for a transfer.
+// A negative total means the transfer size is unknown.
+type ProgressFunc func(done, total int64)
+
+// TransferOptions contains optional transfer behavior.
+type TransferOptions struct {
+	Progress ProgressFunc
+}
+
+func reportProgress(progress ProgressFunc, done, total int64) {
+	if progress != nil {
+		progress(done, total)
+	}
+}
+
+type progressReader struct {
+	reader   io.Reader
+	total    int64
+	done     int64
+	progress ProgressFunc
+}
+
+func (r *progressReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		r.done += int64(n)
+		reportProgress(r.progress, r.done, r.total)
+	}
+	return n, err
+}

--- a/internal/ssm/progress.go
+++ b/internal/ssm/progress.go
@@ -30,5 +30,5 @@ func (r *progressReader) Read(p []byte) (int, error) {
 		r.done += int64(n)
 		reportProgress(r.progress, r.done, r.total)
 	}
-	return n, err
+	return n, err //nolint:wrapcheck // io.Reader implementations must preserve sentinel errors such as io.EOF.
 }

--- a/internal/ssm/transfer.go
+++ b/internal/ssm/transfer.go
@@ -133,7 +133,9 @@ func UploadWithOptions(ctx context.Context, client RunAPI, target TargetInfo, lo
 		if rawDone > totalBytes {
 			rawDone = totalBytes
 		}
-		reportProgress(opts.Progress, rawDone, totalBytes)
+		if rawDone < totalBytes {
+			reportProgress(opts.Progress, rawDone, totalBytes)
+		}
 	}
 
 	finaliseCmd := fmt.Sprintf("mkdir -p %s && mv %s %s", path.Dir(remotePath), tempFile, remotePath)
@@ -152,6 +154,7 @@ func UploadWithOptions(ctx context.Context, client RunAPI, target TargetInfo, lo
 	if result.ExitCode != 0 {
 		return nil, fmt.Errorf("move command failed: %s", result.Stderr)
 	}
+	reportProgress(opts.Progress, totalBytes, totalBytes)
 
 	return &TransferResult{
 		Direction:   "upload",

--- a/internal/ssm/transfer.go
+++ b/internal/ssm/transfer.go
@@ -66,10 +66,18 @@ func ParseArg(s string) (instance, path string, isRemote bool) {
 // heredoc. The 'EOF' delimiter is single-quoted, which prevents shell
 // interpretation of any characters in the chunk (i.e., +, /, =).
 func Upload(ctx context.Context, client RunAPI, target TargetInfo, localPath, remotePath string, timeout time.Duration) (*TransferResult, error) {
+	return UploadWithOptions(ctx, client, target, localPath, remotePath, timeout, TransferOptions{})
+}
+
+// UploadWithOptions copies a local file to a remote instance via SSM with
+// optional progress reporting.
+func UploadWithOptions(ctx context.Context, client RunAPI, target TargetInfo, localPath, remotePath string, timeout time.Duration, opts TransferOptions) (*TransferResult, error) {
 	data, err := os.ReadFile(localPath) // #nosec G304 -- localPath is a user-supplied CLI argument, path traversal is intentional
 	if err != nil {
 		return nil, fmt.Errorf("failed to read local file: %w", err)
 	}
+	totalBytes := int64(len(data))
+	reportProgress(opts.Progress, 0, totalBytes)
 
 	encoded := base64.StdEncoding.EncodeToString(data)
 	tempFile := tempFileForTarget(target)
@@ -121,6 +129,11 @@ func Upload(ctx context.Context, client RunAPI, target TargetInfo, localPath, re
 			return nil, fmt.Errorf("chunk command failed: %s", result.Stderr)
 		}
 		chunks++
+		rawDone := int64(end / 4 * 3)
+		if rawDone > totalBytes {
+			rawDone = totalBytes
+		}
+		reportProgress(opts.Progress, rawDone, totalBytes)
 	}
 
 	finaliseCmd := fmt.Sprintf("mkdir -p %s && mv %s %s", path.Dir(remotePath), tempFile, remotePath)
@@ -144,7 +157,7 @@ func Upload(ctx context.Context, client RunAPI, target TargetInfo, localPath, re
 		Direction:   "upload",
 		Source:      localPath,
 		Destination: target.InstanceID + ":" + remotePath,
-		Bytes:       int64(len(data)),
+		Bytes:       totalBytes,
 		Chunks:      chunks,
 	}, nil
 }
@@ -152,6 +165,12 @@ func Upload(ctx context.Context, client RunAPI, target TargetInfo, localPath, re
 // Download copies a remote file to a local path via SSM.
 // Practical limit: ~36KB due to SSM stdout truncation.
 func Download(ctx context.Context, client RunAPI, target TargetInfo, remotePath, localPath string, timeout time.Duration) (*TransferResult, error) {
+	return DownloadWithOptions(ctx, client, target, remotePath, localPath, timeout, TransferOptions{})
+}
+
+// DownloadWithOptions copies a remote file to a local path via SSM with
+// optional progress reporting.
+func DownloadWithOptions(ctx context.Context, client RunAPI, target TargetInfo, remotePath, localPath string, timeout time.Duration, opts TransferOptions) (*TransferResult, error) {
 	command := fmt.Sprintf("cat %s | base64", remotePath)
 	if target.IsWindows() {
 		remotePath = normalizeWindowsPath(remotePath)
@@ -174,6 +193,7 @@ func Download(ctx context.Context, client RunAPI, target TargetInfo, remotePath,
 	if err := os.WriteFile(localPath, data, 0o600); err != nil {
 		return nil, fmt.Errorf("failed to write local file: %w", err)
 	}
+	reportProgress(opts.Progress, int64(len(data)), int64(len(data)))
 
 	return &TransferResult{
 		Direction:   "download",

--- a/internal/ssm/transfer_s3.go
+++ b/internal/ssm/transfer_s3.go
@@ -116,6 +116,22 @@ func UploadViaS3(
 	keepStaging bool,
 	timeout time.Duration,
 ) (*TransferResult, error) {
+	return UploadViaS3WithOptions(ctx, ssmClient, s3Client, target, localPath, remotePath, staging, keepStaging, timeout, TransferOptions{})
+}
+
+// UploadViaS3WithOptions stages a local file in S3 with optional progress
+// reporting.
+func UploadViaS3WithOptions(
+	ctx context.Context,
+	ssmClient RunAPI,
+	s3Client S3API,
+	target TargetInfo,
+	localPath, remotePath string,
+	staging S3Location,
+	keepStaging bool,
+	timeout time.Duration,
+	opts TransferOptions,
+) (*TransferResult, error) {
 	file, err := os.Open(localPath) // #nosec G304 -- localPath is user-supplied via CLI
 	if err != nil {
 		return nil, fmt.Errorf("failed to open local file: %w", err)
@@ -126,16 +142,21 @@ func UploadViaS3(
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat local file: %w", err)
 	}
+	reportProgress(opts.Progress, 0, stat.Size())
 
 	key, err := stagingKeyFunc(staging.Prefix, filepath.Base(localPath))
 	if err != nil {
 		return nil, err
 	}
+	body := io.Reader(file)
+	if opts.Progress != nil {
+		body = &progressReader{reader: file, total: stat.Size(), progress: opts.Progress}
+	}
 
 	if _, err := s3Client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(staging.Bucket),
 		Key:    aws.String(key),
-		Body:   file,
+		Body:   body,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to stage file in S3: %w", err)
 	}
@@ -199,6 +220,22 @@ func DownloadViaS3(
 	keepStaging bool,
 	timeout time.Duration,
 ) (*TransferResult, error) {
+	return DownloadViaS3WithOptions(ctx, ssmClient, s3Client, target, remotePath, localPath, staging, keepStaging, timeout, TransferOptions{})
+}
+
+// DownloadViaS3WithOptions downloads a staged S3 object locally with optional
+// progress reporting.
+func DownloadViaS3WithOptions(
+	ctx context.Context,
+	ssmClient RunAPI,
+	s3Client S3API,
+	target TargetInfo,
+	remotePath, localPath string,
+	staging S3Location,
+	keepStaging bool,
+	timeout time.Duration,
+	opts TransferOptions,
+) (*TransferResult, error) {
 	// Derive the staging basename from the original user path before any
 	// Windows-only normalization. remoteBaseName handles backslash conversion
 	// itself, so keeping the raw path here avoids coupling key naming to the
@@ -234,7 +271,7 @@ func DownloadViaS3(
 		return nil, fmt.Errorf("remote aws s3 cp failed: %s", strings.TrimSpace(pushed.Stderr))
 	}
 
-	bytes, getErr := fetchStagedObject(ctx, s3Client, staging.Bucket, key, localPath)
+	bytes, getErr := fetchStagedObject(ctx, s3Client, staging.Bucket, key, localPath, opts)
 	cleanupErr := maybeCleanupStagingObject(ctx, s3Client, staging.Bucket, key, keepStaging, getErr == nil)
 	if getErr != nil {
 		return nil, getErr
@@ -254,7 +291,7 @@ func DownloadViaS3(
 	}, nil
 }
 
-func fetchStagedObject(ctx context.Context, s3Client S3API, bucket, key, localPath string) (int64, error) {
+func fetchStagedObject(ctx context.Context, s3Client S3API, bucket, key, localPath string, opts TransferOptions) (int64, error) {
 	out, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -270,10 +307,25 @@ func fetchStagedObject(ctx context.Context, s3Client S3API, bucket, key, localPa
 	}
 	defer func() { _ = dst.Close() }()
 
-	n, err := io.Copy(dst, out.Body)
+	total := int64(-1)
+	if out.ContentLength != nil {
+		total = *out.ContentLength
+	}
+	reportProgress(opts.Progress, 0, total)
+	body := io.Reader(out.Body)
+	if opts.Progress != nil {
+		body = &progressReader{reader: out.Body, total: total, progress: opts.Progress}
+	}
+
+	n, err := io.Copy(dst, body)
 	if err != nil {
 		return 0, fmt.Errorf("failed to write local file: %w", err)
 	}
+	if total < 0 {
+		reportProgress(opts.Progress, n, n)
+		return n, nil
+	}
+	reportProgress(opts.Progress, n, total)
 	return n, nil
 }
 

--- a/internal/ssm/transfer_s3_test.go
+++ b/internal/ssm/transfer_s3_test.go
@@ -117,6 +117,16 @@ func TestDefaultStagingKey_NoPrefix(t *testing.T) {
 	}
 }
 
+func TestStagingKey(t *testing.T) {
+	key, err := StagingKey("tmp/", "../payload.txt")
+	if err != nil {
+		t.Fatalf("StagingKey error: %v", err)
+	}
+	if !strings.HasPrefix(key, "tmp/ssmctl-") || !strings.HasSuffix(key, "-payload.txt") {
+		t.Fatalf("StagingKey = %q, want key under tmp with sanitized basename", key)
+	}
+}
+
 func TestSanitizeBasename_StripsPathSeparators(t *testing.T) {
 	k, err := defaultStagingKey("tmp", "/etc/../../passwd")
 	if err != nil {
@@ -162,6 +172,7 @@ type mockS3Client struct {
 	getCalls     int
 	capturedPuts []string
 	capturedGets []string
+	noLength     bool
 }
 
 func newMockS3Client() *mockS3Client {
@@ -196,8 +207,12 @@ func (m *mockS3Client) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...
 	if !ok {
 		return nil, errors.New("NoSuchKey")
 	}
-	contentLength := int64(len(data))
-	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data)), ContentLength: &contentLength}, nil
+	out := &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data))}
+	if !m.noLength {
+		contentLength := int64(len(data))
+		out.ContentLength = &contentLength
+	}
+	return out, nil
 }
 
 func (m *mockS3Client) DeleteObject(_ context.Context, in *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
@@ -534,6 +549,43 @@ func TestDownloadViaS3WithOptionsReportsProgress(t *testing.T) {
 	}
 	if events[0] != [2]int64{0, int64(len(content))} {
 		t.Fatalf("first progress event = %v, want 0/%d", events[0], len(content))
+	}
+	if got := events[len(events)-1]; got != [2]int64{int64(len(content)), int64(len(content))} {
+		t.Fatalf("final progress event = %v, want %d/%d", got, len(content), len(content))
+	}
+}
+
+func TestDownloadViaS3WithOptionsReportsProgressWithoutContentLength(t *testing.T) {
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	withFixedStagingKey(t, "tmp/ssmctl-progress-unknown.log")
+
+	content := []byte("unknown length")
+	mockS3 := newMockS3Client()
+	mockS3.objects["my-bucket/tmp/ssmctl-progress-unknown.log"] = content
+	mockS3.noLength = true
+
+	localFile := filepath.Join(t.TempDir(), "unknown.log")
+	var events [][2]int64
+	_, err := DownloadViaS3WithOptions(
+		context.Background(),
+		ssmRunCapturer(nil, 0, ""),
+		mockS3,
+		TargetInfo{InstanceID: "i-123"},
+		"/var/log/unknown.log", localFile,
+		S3Location{Bucket: "my-bucket", Prefix: "tmp"},
+		false,
+		30*time.Second,
+		TransferOptions{Progress: func(done, total int64) {
+			events = append(events, [2]int64{done, total})
+		}},
+	)
+	if err != nil {
+		t.Fatalf("DownloadViaS3WithOptions error: %v", err)
+	}
+	if events[0] != [2]int64{0, -1} {
+		t.Fatalf("first progress event = %v, want unknown total", events[0])
 	}
 	if got := events[len(events)-1]; got != [2]int64{int64(len(content)), int64(len(content))} {
 		t.Fatalf("final progress event = %v, want %d/%d", got, len(content), len(content))

--- a/internal/ssm/transfer_s3_test.go
+++ b/internal/ssm/transfer_s3_test.go
@@ -196,7 +196,8 @@ func (m *mockS3Client) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...
 	if !ok {
 		return nil, errors.New("NoSuchKey")
 	}
-	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data))}, nil
+	contentLength := int64(len(data))
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data)), ContentLength: &contentLength}, nil
 }
 
 func (m *mockS3Client) DeleteObject(_ context.Context, in *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
@@ -305,6 +306,43 @@ func TestUploadViaS3_Success(t *testing.T) {
 	}
 	if result.KeptStaging {
 		t.Error("KeptStaging = true, want false")
+	}
+}
+
+func TestUploadViaS3WithOptionsReportsProgress(t *testing.T) {
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	withFixedStagingKey(t, "tmp/ssmctl-progress-payload.bin")
+
+	content := []byte(strings.Repeat("x", 4096))
+	localFile := filepath.Join(t.TempDir(), "payload.bin")
+	if err := os.WriteFile(localFile, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var events [][2]int64
+	_, err := UploadViaS3WithOptions(
+		context.Background(),
+		ssmRunCapturer(nil, 0, ""),
+		newMockS3Client(),
+		TargetInfo{InstanceID: "i-123"},
+		localFile, "/var/data/payload.bin",
+		S3Location{Bucket: "my-bucket", Prefix: "tmp"},
+		false,
+		30*time.Second,
+		TransferOptions{Progress: func(done, total int64) {
+			events = append(events, [2]int64{done, total})
+		}},
+	)
+	if err != nil {
+		t.Fatalf("UploadViaS3WithOptions error: %v", err)
+	}
+	if events[0] != [2]int64{0, int64(len(content))} {
+		t.Fatalf("first progress event = %v, want 0/%d", events[0], len(content))
+	}
+	if got := events[len(events)-1]; got != [2]int64{int64(len(content)), int64(len(content))} {
+		t.Fatalf("final progress event = %v, want %d/%d", got, len(content), len(content))
 	}
 }
 
@@ -463,6 +501,42 @@ func TestDownloadViaS3_Success(t *testing.T) {
 	}
 	if result.Bytes != int64(len("LARGE LOG CONTENT")) {
 		t.Errorf("Bytes = %d", result.Bytes)
+	}
+}
+
+func TestDownloadViaS3WithOptionsReportsProgress(t *testing.T) {
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	withFixedStagingKey(t, "tmp/ssmctl-progress-app.log")
+
+	content := []byte(strings.Repeat("x", 4096))
+	mockS3 := newMockS3Client()
+	mockS3.objects["my-bucket/tmp/ssmctl-progress-app.log"] = content
+
+	localFile := filepath.Join(t.TempDir(), "app.log")
+	var events [][2]int64
+	_, err := DownloadViaS3WithOptions(
+		context.Background(),
+		ssmRunCapturer(nil, 0, ""),
+		mockS3,
+		TargetInfo{InstanceID: "i-123"},
+		"/var/log/app.log", localFile,
+		S3Location{Bucket: "my-bucket", Prefix: "tmp"},
+		false,
+		30*time.Second,
+		TransferOptions{Progress: func(done, total int64) {
+			events = append(events, [2]int64{done, total})
+		}},
+	)
+	if err != nil {
+		t.Fatalf("DownloadViaS3WithOptions error: %v", err)
+	}
+	if events[0] != [2]int64{0, int64(len(content))} {
+		t.Fatalf("first progress event = %v, want 0/%d", events[0], len(content))
+	}
+	if got := events[len(events)-1]; got != [2]int64{int64(len(content)), int64(len(content))} {
+		t.Fatalf("final progress event = %v, want %d/%d", got, len(content), len(content))
 	}
 }
 

--- a/internal/ssm/transfer_test.go
+++ b/internal/ssm/transfer_test.go
@@ -225,6 +225,55 @@ func TestDownload(t *testing.T) {
 	}
 }
 
+func TestDownloadWithOptionsReportsProgress(t *testing.T) {
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	content := "hello progress download"
+	encoded := base64.StdEncoding.EncodeToString([]byte(content))
+
+	client := &mockSSMRunClient{
+		sendCommandFn: func(_ context.Context, _ *ssm.SendCommandInput, _ ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
+			return &ssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-dl-progress")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *ssm.GetCommandInvocationInput, _ ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
+			return &ssm.GetCommandInvocationOutput{
+				Status:                types.CommandInvocationStatusSuccess,
+				StandardOutputContent: aws.String(encoded),
+				ResponseCode:          0,
+			}, nil
+		},
+	}
+
+	localFile := filepath.Join(t.TempDir(), "download.txt")
+	var events [][2]int64
+
+	_, err := DownloadWithOptions(
+		context.Background(),
+		client,
+		TargetInfo{InstanceID: "i-123"},
+		"/remote/file.txt",
+		localFile,
+		30*time.Second,
+		TransferOptions{Progress: func(done, total int64) {
+			events = append(events, [2]int64{done, total})
+		}},
+	)
+	if err != nil {
+		t.Fatalf("DownloadWithOptions() error = %v", err)
+	}
+
+	want := [2]int64{int64(len(content)), int64(len(content))}
+	if len(events) != 1 {
+		t.Fatalf("progress events = %v, want one terminal event", events)
+	}
+	if events[0] != want {
+		t.Fatalf("progress event = %v, want %d/%d", events[0], len(content), len(content))
+	}
+}
+
 func TestDownload_RemoteCommandFails(t *testing.T) {
 	pollInterval = 10 * time.Millisecond
 	t.Cleanup(func() { pollInterval = 2 * time.Second })

--- a/internal/ssm/transfer_test.go
+++ b/internal/ssm/transfer_test.go
@@ -135,6 +135,42 @@ func TestUpload(t *testing.T) {
 	}
 }
 
+func TestUploadWithOptionsReportsProgress(t *testing.T) {
+	pollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { pollInterval = 2 * time.Second })
+
+	content := []byte(strings.Repeat("x", 5000))
+	localFile := filepath.Join(t.TempDir(), "upload.txt")
+	if err := os.WriteFile(localFile, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var events [][2]int64
+	_, err := UploadWithOptions(
+		context.Background(),
+		alwaysSucceedClient(),
+		TargetInfo{InstanceID: "i-123"},
+		localFile,
+		"/tmp/upload.txt",
+		30*time.Second,
+		TransferOptions{Progress: func(done, total int64) {
+			events = append(events, [2]int64{done, total})
+		}},
+	)
+	if err != nil {
+		t.Fatalf("UploadWithOptions() error = %v", err)
+	}
+	if len(events) < 3 {
+		t.Fatalf("progress events = %v, want initial, chunk, and completion events", events)
+	}
+	if events[0] != [2]int64{0, int64(len(content))} {
+		t.Fatalf("first progress event = %v, want 0/%d", events[0], len(content))
+	}
+	if got := events[len(events)-1]; got != [2]int64{int64(len(content)), int64(len(content))} {
+		t.Fatalf("final progress event = %v, want %d/%d", got, len(content), len(content))
+	}
+}
+
 func TestDownload(t *testing.T) {
 	pollInterval = 10 * time.Millisecond
 	t.Cleanup(func() { pollInterval = 2 * time.Second })

--- a/internal/ssm/transfer_test.go
+++ b/internal/ssm/transfer_test.go
@@ -145,16 +145,42 @@ func TestUploadWithOptionsReportsProgress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var events [][2]int64
+	var commands []string
+	client := &mockSSMRunClient{
+		sendCommandFn: func(_ context.Context, input *ssm.SendCommandInput, _ ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
+			commands = append(commands, input.Parameters["commands"]...)
+			return &ssm.SendCommandOutput{
+				Command: &types.Command{CommandId: aws.String("cmd-upload-progress")},
+			}, nil
+		},
+		getCommandInvocationFn: func(_ context.Context, _ *ssm.GetCommandInvocationInput, _ ...func(*ssm.Options)) (*ssm.GetCommandInvocationOutput, error) {
+			return &ssm.GetCommandInvocationOutput{
+				Status:                types.CommandInvocationStatusSuccess,
+				StandardOutputContent: aws.String(""),
+				ResponseCode:          0,
+			}, nil
+		},
+	}
+
+	type progressEvent struct {
+		done         int64
+		total        int64
+		commandsSeen int
+	}
+	var events []progressEvent
 	_, err := UploadWithOptions(
 		context.Background(),
-		alwaysSucceedClient(),
+		client,
 		TargetInfo{InstanceID: "i-123"},
 		localFile,
 		"/tmp/upload.txt",
 		30*time.Second,
 		TransferOptions{Progress: func(done, total int64) {
-			events = append(events, [2]int64{done, total})
+			events = append(events, progressEvent{
+				done:         done,
+				total:        total,
+				commandsSeen: len(commands),
+			})
 		}},
 	)
 	if err != nil {
@@ -163,11 +189,17 @@ func TestUploadWithOptionsReportsProgress(t *testing.T) {
 	if len(events) < 3 {
 		t.Fatalf("progress events = %v, want initial, chunk, and completion events", events)
 	}
-	if events[0] != [2]int64{0, int64(len(content))} {
+	if events[0].done != 0 || events[0].total != int64(len(content)) {
 		t.Fatalf("first progress event = %v, want 0/%d", events[0], len(content))
 	}
-	if got := events[len(events)-1]; got != [2]int64{int64(len(content)), int64(len(content))} {
+	if got := events[len(events)-1]; got.done != int64(len(content)) || got.total != int64(len(content)) {
 		t.Fatalf("final progress event = %v, want %d/%d", got, len(content), len(content))
+	}
+	if got := events[len(events)-1].commandsSeen; got != len(commands) {
+		t.Fatalf("final progress event saw %d commands, want %d", got, len(commands))
+	}
+	if !strings.Contains(commands[len(commands)-1], "mv /tmp/._ssmctl_transfer /tmp/upload.txt") {
+		t.Fatalf("final command = %q, want move to destination", commands[len(commands)-1])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add progress reporting hooks for cp transfers without changing existing transfer APIs.
- Render byte-count progress to stderr for interactive text output only.
- Suppress progress for JSON output and non-TTY stdout so pipes and automation stay quiet.
- Cover in-band upload, S3 upload/download progress, and command-layer formatting/suppression.

Fixes #168.

## Validation

- `docker run --rm -u $(id -u):$(id -g) -e GOCACHE=/tmp/go-build -e GOPATH=/tmp/go -v "$PWD":/workspace -w /workspace golang:1.26.4 go test ./internal/ssm ./internal/cmd`
- `docker run --rm -u $(id -u):$(id -g) -e GOCACHE=/tmp/go-build -e GOPATH=/tmp/go -v "$PWD":/workspace -w /workspace golang:1.26.4 go test ./e2e/ -v -count=1`
- `docker run --rm -u $(id -u):$(id -g) -e GOCACHE=/tmp/go-build -e GOPATH=/tmp/go -v "$PWD":/workspace -w /workspace golang:1.26.4 go vet ./...`
- `docker run --rm -u $(id -u):$(id -g) -e GOCACHE=/tmp/go-build -e GOPATH=/tmp/go -v "$PWD":/workspace -w /workspace golang:1.26.4 go test ./...`
- `docker run --rm -u $(id -u):$(id -g) -e GOCACHE=/tmp/go-build -e GOPATH=/tmp/go -v "$PWD":/workspace -w /workspace golang:1.26.4 go build -o bin/ssmctl ./cmd/ssmctl`
- `docker run --rm -u $(id -u):$(id -g) -e GOCACHE=/tmp/go-build -e GOPATH=/tmp/go -v "$PWD":/workspace -w /workspace golang:1.26.4 go test -race -coverprofile=coverage.out ./cmd/... ./internal/...`
